### PR TITLE
chore: remove node@20 from CI pipeline

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
currently we run our CI pipeline on node@20 because it is the last LTS and node@22 because it is the newest version. IMHO it doesn't make sense to keep node@20 because next year node@22 will be the next LTS:

<img width="688" alt="Screenshot 2024-07-29 at 17 58 17" src="https://github.com/user-attachments/assets/2baf0c22-ae55-4c54-994e-798e3f86c395">
