### PR TITLE
PVM: decode jump table from bytes

### DIFF
--- a/packages/pvm/program-decoder/jump-table.test.ts
+++ b/packages/pvm/program-decoder/jump-table.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+import { JumpTable } from "./jump-table";
+
+describe("JumpTable", () => {
+  it("should return true when an index exist in jump table", () => {
+    const jumpTableItemLength = 4;
+    const bytes = new Uint8Array([0xe0, 0, 0, 0x20]);
+    const jumpTable = new JumpTable(jumpTableItemLength, bytes);
+    const indexToCheck = 2 ** 21;
+
+    const result = jumpTable.hasIndex(indexToCheck);
+
+    assert.strictEqual(result, true);
+  });
+
+  it("should return false when an index not exist in jump table", () => {
+    const jumpTableItemLength = 4;
+    const bytes = new Uint8Array([0xe0, 0, 0, 0x20]);
+    const jumpTable = new JumpTable(jumpTableItemLength, bytes);
+    const indexToCheck = 2 ** 21 + 1;
+
+    const result = jumpTable.hasIndex(indexToCheck);
+
+    assert.strictEqual(result, false);
+  });
+});

--- a/packages/pvm/program-decoder/jump-table.ts
+++ b/packages/pvm/program-decoder/jump-table.ts
@@ -1,0 +1,27 @@
+import { decodeNaturalNumber } from "@typeberry/jam-codec";
+import { check } from "@typeberry/utils";
+
+export class JumpTable {
+  private indexes = new Set<number>();
+
+  constructor(jumpTableItemLength: number, bytes: Uint8Array) {
+    check(
+      bytes.length % jumpTableItemLength === 0,
+      `Length of jump table (${bytes.length}) should be a multiple of item lenght (${jumpTableItemLength})!`,
+    );
+
+    for (let i = 0; i < bytes.length; i += jumpTableItemLength) {
+      const index = this.decodeItem(bytes.subarray(i, i + jumpTableItemLength));
+      this.indexes.add(index);
+    }
+  }
+
+  private decodeItem(bytes: Uint8Array) {
+    const { value } = decodeNaturalNumber(bytes);
+    return Number(value);
+  }
+
+  hasIndex(index: number) {
+    return this.indexes.has(index);
+  }
+}

--- a/packages/pvm/program-decoder/program-decoder.test.ts
+++ b/packages/pvm/program-decoder/program-decoder.test.ts
@@ -1,29 +1,39 @@
 import assert from "node:assert";
-import { test } from "node:test";
+import { describe, it } from "node:test";
 
+import { JumpTable } from "./jump-table";
 import { Mask } from "./mask";
 import { ProgramDecoder } from "./program-decoder";
 
 const code = [4, 7, 246, 4, 8, 10, 41, 135, 4, 0, 4, 7, 239, 190, 173, 222];
 
+const jumpTableItemLength = 1;
+const jumpTable = [5];
 const bitMask = [73, 6];
+const program = new Uint8Array([jumpTable.length, jumpTableItemLength, 16, ...jumpTable, ...code, ...bitMask]);
 
-const program = [0, 0, 16, ...code, ...bitMask];
-
-test("ProgramDecoder", async (t) => {
-  await t.test("should corectly decode instructions", () => {
-    const programDecoder = new ProgramDecoder(new Uint8Array(program));
+describe("ProgramDecoder", () => {
+  it("should corectly decode instructions", () => {
+    const programDecoder = new ProgramDecoder(program);
 
     const result = programDecoder.getCode();
 
     assert.deepStrictEqual(result, new Uint8Array(code));
   });
 
-  await t.test("should corectly decode mask", () => {
-    const programDecoder = new ProgramDecoder(new Uint8Array(program));
+  it("should corectly decode mask", () => {
+    const programDecoder = new ProgramDecoder(program);
 
     const result = programDecoder.getMask();
 
     assert.deepStrictEqual(result, new Mask(new Uint8Array(bitMask)));
+  });
+
+  it("should corectly decode jump table", () => {
+    const programDecoder = new ProgramDecoder(program);
+
+    const result = programDecoder.getJumpTable();
+
+    assert.deepStrictEqual(result, new JumpTable(jumpTableItemLength, new Uint8Array(jumpTable)));
   });
 });

--- a/packages/pvm/program-decoder/program-decoder.ts
+++ b/packages/pvm/program-decoder/program-decoder.ts
@@ -1,25 +1,28 @@
 import { decodeNaturalNumber } from "@typeberry/jam-codec";
+import { JumpTable } from "./jump-table";
 import { Mask } from "./mask";
 
 export class ProgramDecoder {
   private code: Uint8Array;
   private mask: Mask;
+  private jumpTable: JumpTable;
 
   constructor(rawProgram: Uint8Array) {
-    const { code, mask } = this.decodeProgram(rawProgram);
+    const { code, mask, jumpTable, jumpTableItemLength } = this.decodeProgram(rawProgram);
 
     this.code = new Uint8Array(code);
     this.mask = new Mask(mask);
+    this.jumpTable = new JumpTable(jumpTableItemLength, jumpTable);
   }
 
   private decodeProgram(program: Uint8Array) {
     const { value: jumpTableLength, bytesToSkip: firstNumberLength } = decodeNaturalNumber(program);
-    const jumpTableItemSize = program[firstNumberLength];
+    const jumpTableItemLength = program[firstNumberLength];
     const { value: codeLength, bytesToSkip: thirdNumberLenght } = decodeNaturalNumber(
       program.subarray(firstNumberLength + 1),
     );
     const jumpTableFirstByteIndex = firstNumberLength + 1 + thirdNumberLenght;
-    const jumpTableLengthInBytes = Number(jumpTableLength) * jumpTableItemSize;
+    const jumpTableLengthInBytes = Number(jumpTableLength) * jumpTableItemLength;
     const jumpTable = program.subarray(jumpTableFirstByteIndex, jumpTableFirstByteIndex + jumpTableLengthInBytes);
     const codeFirstIndex = jumpTableFirstByteIndex + jumpTableLengthInBytes;
     const code = program.subarray(codeFirstIndex, codeFirstIndex + Number(codeLength));
@@ -30,6 +33,7 @@ export class ProgramDecoder {
     return {
       mask,
       code,
+      jumpTableItemLength,
       jumpTable,
     };
   }
@@ -40,5 +44,9 @@ export class ProgramDecoder {
 
   getCode() {
     return this.code;
+  }
+
+  getJumpTable() {
+    return this.jumpTable;
   }
 }


### PR DESCRIPTION
# What?
I added logic to decode dynamic jump table from bytes. Currently it is not used but it will be needed soon to validate jumps. 

As the jump table is a set of indices, my first idea was to add this logic to `ProgramDecoder` class. I decided to extract it to a separate class because currently it uses `Set` under the hood and I am not sure if it is the fastest solution so probably we will do some benchmarking here so I decided to extract this code to make it easier.

# GP references:
<img width="821" alt="Screenshot 2024-07-31 at 22 25 44" src="https://github.com/user-attachments/assets/f728c92f-a414-4b87-9051-e476da46f9ec">
