### PR TITLE
refactor: change tests to use describe/it syntax

### DIFF
--- a/packages/bytes/bytes.test.ts
+++ b/packages/bytes/bytes.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert";
-import { test } from "node:test";
+import { describe, it } from "node:test";
 import { Bytes, BytesBlob } from "./bytes";
 
-test("BytesBlob", async (t) => {
-  await t.test("should fail if 0x is missing", () => {
+describe("BytesBlob", () => {
+  it("should fail if 0x is missing", () => {
     try {
       BytesBlob.parseBlob("ff2f");
       assert.fail("Should throw an exception");
@@ -12,7 +12,7 @@ test("BytesBlob", async (t) => {
     }
   });
 
-  await t.test("should fail in case invalid characters are given", () => {
+  it("should fail in case invalid characters are given", () => {
     try {
       BytesBlob.parseBlob("0xff2g");
       assert.fail("Should throw an exception");
@@ -21,7 +21,7 @@ test("BytesBlob", async (t) => {
     }
   });
 
-  await t.test("parse 0x-prefixed hex string into blob of bytes", () => {
+  it("parse 0x-prefixed hex string into blob of bytes", () => {
     const input = "0x2fa3f686df876995167e7c2e5d74c4c7b6e48f8068fe0e44208344d480f7904c";
     const result = BytesBlob.parseBlob(input);
 
@@ -34,7 +34,7 @@ test("BytesBlob", async (t) => {
     );
   });
 
-  await t.test("parse non 0x-prefixed hex string into blob of bytes", () => {
+  it("parse non 0x-prefixed hex string into blob of bytes", () => {
     const input = "2fa3f686df876995167e7c2e5d74c4c7b6e48f8068fe0e44208344d480f7904c";
     const result = BytesBlob.parseBlobNoPrefix(input);
 
@@ -47,15 +47,15 @@ test("BytesBlob", async (t) => {
     );
   });
 
-  await t.test("from bytes", () => {
+  it("from bytes", () => {
     const result = BytesBlob.fromBytes([47, 163, 246, 134]);
 
     assert.deepStrictEqual(result.buffer, new Uint8Array([47, 163, 246, 134]));
   });
 });
 
-test("Bytes", async (t) => {
-  await t.test("should fail in case of length mismatch", () => {
+describe("Bytes", () => {
+  it("should fail in case of length mismatch", () => {
     const input = "0x9c2d3bce7aa0a5857c67a85247365d2035f7d9daec2b515e86086584ad5e8644";
 
     try {
@@ -66,7 +66,7 @@ test("Bytes", async (t) => {
     }
   });
 
-  await t.test("parse 0x-prefixed, fixed length bytes vector", () => {
+  it("parse 0x-prefixed, fixed length bytes vector", () => {
     const input = "0x9c2d3bce7aa0a5857c67a85247365d2035f7d9daec2b515e86086584ad5e8644";
 
     const bytes = Bytes.parseBytes(input, 32);
@@ -80,7 +80,7 @@ test("Bytes", async (t) => {
     );
   });
 
-  await t.test("parse non 0x-prefixed, fixed length bytes vector", () => {
+  it("parse non 0x-prefixed, fixed length bytes vector", () => {
     const input = "9c2d3bce7aa0a5857c67a85247365d2035f7d9daec2b515e86086584ad5e8644";
 
     const bytes = Bytes.parseBytesNoPrefix(input, 32);

--- a/packages/jam-codec/decode-natural-number.test.ts
+++ b/packages/jam-codec/decode-natural-number.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert";
-import { test } from "node:test";
+import { describe, it } from "node:test";
 
 import { decodeNaturalNumber } from "./decode-natural-number";
 
-test("decodeNaturalNumber", async (t) => {
-  await t.test("decode 0", () => {
+describe("decodeNaturalNumber", () => {
+  it("decode 0", () => {
     const encodedBytes = new Uint8Array([0]);
     const expectedValue = 0n;
 
@@ -14,7 +14,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode single byte min value", () => {
+  it("decode single byte min value", () => {
     const encodedBytes = new Uint8Array([1]);
     const expectedValue = 1n;
 
@@ -24,7 +24,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode single byte max value", () => {
+  it("decode single byte max value", () => {
     const encodedBytes = new Uint8Array([127]);
     const expectedValue = 127n;
 
@@ -34,7 +34,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 2 bytes min value", () => {
+  it("decode 2 bytes min value", () => {
     const encodedBytes = new Uint8Array([128, 128]);
     const expectedValue = 128n;
 
@@ -44,7 +44,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 2 bytes max value", () => {
+  it("decode 2 bytes max value", () => {
     const encodedBytes = new Uint8Array([191, 255]);
     const expectedValue = 2n ** 14n - 1n;
 
@@ -54,7 +54,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 3 bytes min value", () => {
+  it("decode 3 bytes min value", () => {
     const encodedBytes = new Uint8Array([192, 0, 0x40]);
     const expectedValue = 2n ** 14n;
 
@@ -64,7 +64,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 3 bytes max value", () => {
+  it("decode 3 bytes max value", () => {
     const encodedBytes = new Uint8Array([192 + 31, 0xff, 0xff]);
     const expectedValue = 2n ** 21n - 1n;
 
@@ -74,7 +74,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 4 bytes min value", () => {
+  it("decode 4 bytes min value", () => {
     const encodedBytes = new Uint8Array([0xe0, 0, 0, 0x20]);
     const expectedValue = 2n ** 21n;
 
@@ -84,7 +84,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 4 bytes max value", () => {
+  it("decode 4 bytes max value", () => {
     const encodedBytes = new Uint8Array([0xe0 + 15, 0xff, 0xff, 0xff]);
     const expectedValue = 2n ** 28n - 1n;
 
@@ -94,7 +94,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 5 bytes min value", () => {
+  it("decode 5 bytes min value", () => {
     const encodedBytes = new Uint8Array([256 - 16, 0, 0, 0, 0x10]);
     const expectedValue = 2n ** 28n;
 
@@ -104,7 +104,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 5 bytes max value", () => {
+  it("decode 5 bytes max value", () => {
     const encodedBytes = new Uint8Array([256 - 16 + 7, 0xff, 0xff, 0xff, 0xff]);
     const expectedValue = 2n ** 35n - 1n;
 
@@ -114,7 +114,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 6 bytes min value", () => {
+  it("decode 6 bytes min value", () => {
     const encodedBytes = new Uint8Array([256 - 8, 0, 0, 0, 0, 0x08]);
     const expectedValue = 2n ** 35n;
 
@@ -124,7 +124,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 6 bytes max value", () => {
+  it("decode 6 bytes max value", () => {
     const encodedBytes = new Uint8Array([256 - 8 + 3, 0xff, 0xff, 0xff, 0xff, 0xff]);
     const expectedValue = 2n ** 42n - 1n;
 
@@ -134,7 +134,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 7 bytes min value", () => {
+  it("decode 7 bytes min value", () => {
     const encodedBytes = new Uint8Array([256 - 4, 0, 0, 0, 0, 0, 0x04]);
     const expectedValue = 2n ** 42n;
 
@@ -144,7 +144,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 7 bytes max value", () => {
+  it("decode 7 bytes max value", () => {
     const encodedBytes = new Uint8Array([256 - 4 + 1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
     const expectedValue = 2n ** 49n - 1n;
 
@@ -154,7 +154,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 8 bytes min value", () => {
+  it("decode 8 bytes min value", () => {
     const encodedBytes = new Uint8Array([256 - 2, 0, 0, 0, 0, 0, 0, 0x02]);
     const expectedValue = 2n ** 49n;
 
@@ -164,7 +164,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 8 bytes max value", () => {
+  it("decode 8 bytes max value", () => {
     const encodedBytes = new Uint8Array([256 - 2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
     const expectedValue = 2n ** 56n - 1n;
 
@@ -174,7 +174,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 9 bytes min value", () => {
+  it("decode 9 bytes min value", () => {
     const encodedBytes = new Uint8Array([255, 0, 0, 0, 0, 0, 0, 0, 0x01]);
     const expectedValue = 2n ** 56n;
 
@@ -184,7 +184,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 9 bytes max value", () => {
+  it("decode 9 bytes max value", () => {
     const encodedBytes = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255, 255]);
     const expectedValue = 2n ** 64n - 1n;
 
@@ -194,7 +194,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, encodedBytes.length);
   });
 
-  await t.test("decode 0 with extra bytes", () => {
+  it("decode 0 with extra bytes", () => {
     const encodedBytes = new Uint8Array([0, 1, 2, 3]);
     const expectedValue = 0n;
 
@@ -204,7 +204,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, 1);
   });
 
-  await t.test("decode 7 bytes number with extra bytes ", () => {
+  it("decode 7 bytes number with extra bytes ", () => {
     const encodedBytes = new Uint8Array([256 - 4 + 1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1, 0x2]);
     const expectedValue = 2n ** 49n - 1n;
 
@@ -214,7 +214,7 @@ test("decodeNaturalNumber", async (t) => {
     assert.strictEqual(result.bytesToSkip, 7);
   });
 
-  await t.test("decode 9 bytes number with extra bytes", () => {
+  it("decode 9 bytes number with extra bytes", () => {
     const encodedBytes = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255, 255, 1, 2, 3]);
     const expectedValue = 2n ** 64n - 1n;
 

--- a/packages/jam-codec/little-endian-decoder.test.ts
+++ b/packages/jam-codec/little-endian-decoder.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert";
-import { test } from "node:test";
+import { describe, it } from "node:test";
 
 import { LittleEndianDecoder } from "./little-endian-decoder";
 
-test("LittleEndianDecoder", async (t) => {
-  await t.test("Empty bytes array", () => {
+describe("LittleEndianDecoder", async (t) => {
+  it("Empty bytes array", () => {
     const decoder = new LittleEndianDecoder();
 
     const encodedBytes = new Uint8Array([]);
@@ -15,7 +15,7 @@ test("LittleEndianDecoder", async (t) => {
     assert.strictEqual(result, expectedValue);
   });
 
-  await t.test("1 byte number", () => {
+  it("1 byte number", () => {
     const decoder = new LittleEndianDecoder();
 
     const encodedBytes = new Uint8Array([0xff]);
@@ -26,7 +26,7 @@ test("LittleEndianDecoder", async (t) => {
     assert.strictEqual(result, expectedValue);
   });
 
-  await t.test("2 bytes number", () => {
+  it("2 bytes number", () => {
     const decoder = new LittleEndianDecoder();
 
     const encodedBytes = new Uint8Array([0xff, 0x01]);
@@ -37,7 +37,7 @@ test("LittleEndianDecoder", async (t) => {
     assert.strictEqual(result, expectedValue);
   });
 
-  await t.test("4 bytes number", () => {
+  it("4 bytes number", () => {
     const decoder = new LittleEndianDecoder();
 
     const encodedBytes = new Uint8Array([0xff, 0x56, 0x34, 0x12]);
@@ -48,7 +48,7 @@ test("LittleEndianDecoder", async (t) => {
     assert.strictEqual(result, expectedValue);
   });
 
-  await t.test("8 bytes number", () => {
+  it("8 bytes number", () => {
     const decoder = new LittleEndianDecoder();
 
     const encodedBytes = new Uint8Array([0xff, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12]);

--- a/packages/safrole/bandersnatch.test.ts
+++ b/packages/safrole/bandersnatch.test.ts
@@ -1,8 +1,8 @@
-import { test } from "node:test";
+import { describe, it } from "node:test";
 import { verifyBandersnatch } from "./bandersnatch";
 
-test("Bandersnatch verification", async (t) => {
-  await t.test("verify", async () => {
+describe("Bandersnatch verification", () => {
+  it("verify", async () => {
     try {
       await verifyBandersnatch();
     } catch (e) {

--- a/packages/stubs/block.test.ts
+++ b/packages/stubs/block.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert";
-import { test } from "node:test";
+import { describe, it } from "node:test";
 
-test("Hello Block", async (t) => {
-  await t.test("subtest", () => {
+describe("Hello Block", () => {
+  it("test", () => {
     assert.strictEqual(1, 1);
   });
 });

--- a/packages/trie/trie.test.ts
+++ b/packages/trie/trie.test.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert";
-import { test } from "node:test";
+import { describe, it } from "node:test";
 import { Bytes, BytesBlob } from "@typeberry/bytes";
 import { blake2bTrieHasher } from "./blake2b.node";
 import { LeafNode, parseStateKey } from "./nodes";
 import { InMemoryTrie } from "./trie";
 
-test("Trie", async () => {
-  await test("Empty trie", () => {
+describe("Trie", async () => {
+  it("Empty trie", () => {
     const trie = InMemoryTrie.empty(blake2bTrieHasher);
 
     assert.deepStrictEqual(
@@ -15,7 +15,7 @@ test("Trie", async () => {
     );
   });
 
-  await test("Leaf Node", () => {
+  it("Leaf Node", () => {
     const key = parseStateKey("16c72e0c2e0b78157e3a116d86d90461a199e439325317aea160b30347adb8ec");
     const value = BytesBlob.parseBlob("0x4227b4a465084852cd87d8f23bec0db6fa7766b9685ab5e095ef9cda9e15e49dff");
     const valueHash = blake2bTrieHasher.hashConcat(value.buffer);
@@ -30,7 +30,7 @@ test("Trie", async () => {
     assert.deepStrictEqual(node.getValueHash(), valueHash);
   });
 
-  await test("Empty value", () => {
+  it("Empty value", () => {
     const trie = InMemoryTrie.empty(blake2bTrieHasher);
 
     trie.set(
@@ -44,7 +44,7 @@ test("Trie", async () => {
     );
   });
 
-  await test("Should import some keys", () => {
+  it("Should import some keys", () => {
     const trie = InMemoryTrie.empty(blake2bTrieHasher);
 
     trie.set(
@@ -58,7 +58,7 @@ test("Trie", async () => {
     );
   });
 
-  await test("Non embedded leaf", () => {
+  it("Non embedded leaf", () => {
     const trie = InMemoryTrie.empty(blake2bTrieHasher);
 
     trie.set(
@@ -72,7 +72,7 @@ test("Trie", async () => {
     );
   });
 
-  await test("More complicated trie", () => {
+  it("More complicated trie", () => {
     const trie = InMemoryTrie.empty(blake2bTrieHasher);
 
     trie.set(
@@ -92,7 +92,7 @@ test("Trie", async () => {
     );
   });
 
-  await test("Move leaf from left to right branch", () => {
+  it("Move leaf from left to right branch", () => {
     const trie = InMemoryTrie.empty(blake2bTrieHasher);
 
     // left value
@@ -119,7 +119,7 @@ test("Trie", async () => {
     );
   });
 
-  await test("Replace leaf value", () => {
+  it("Replace leaf value", () => {
     const trie = InMemoryTrie.empty(blake2bTrieHasher);
     const insert = {
       f2a9fcaf8ae0ff770b0908ebdee1daf8457c0ef5e1106c89ad364236333c5fb3: "0x23",
@@ -145,7 +145,7 @@ test("Trie", async () => {
     );
   });
 
-  await test("Test vector 9", () => {
+  it("Test vector 9", () => {
     const vector = {
       input: {
         d7f99b746f23411983df92806725af8e5cb66eba9f200737accae4a1ab7f47b9:
@@ -162,7 +162,7 @@ test("Trie", async () => {
     runTestVector(vector);
   });
 
-  await test("Test vector 10", () => {
+  it("Test vector 10", () => {
     const vector = {
       input: {
         "5dffe0e2c9f089d30e50b04ee562445cf2c0e7e7d677580ef0ccf2c6fa3522dd":


### PR DESCRIPTION
# What?
I changed tests syntax in part of our packages to use `describe` and `it` instead of `test`. 
 
## Pros:
- no async-await 
- more common syntax - migration to an alternative test framework will be easier 
- tests are split into suites (in case of the previous syntax we had one big suite). I think (but I am not sure) that test suites can be better option to run in parallel  
## Cons
 - ?