### PR TITLE
PVM: add build commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,3 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-
-pvm-dist
-pvm-dist-obfuscated


### PR DESCRIPTION
# What?
I added build commands to generate obfuscated pvm code. 

# How to use it?

it should be enough to run 
```bash
npm run obfuscate-pvm
```
and it should generate 2 dirs:
- `pvm-dist` that contains js files 
- `pvm-dist-obfuscate` that contains the same files what `pvm-dist` but `obfuscated`