### PR TITLE
PVM - add a comment that explains when argsType cannot be matched

### DIFF
--- a/packages/pvm/args-decoder/args-decoder.ts
+++ b/packages/pvm/args-decoder/args-decoder.ts
@@ -274,6 +274,10 @@ export class ArgsDecoder {
       }
 
       default:
+        /**
+         * argsType wasn't matched so the instruction is invalid.
+         * Invalid instruction is treated as trap, hence fallback to ArgumentType.NO_ARGUMENTS
+         */
         return this.results[ArgumentType.NO_ARGUMENTS];
     }
   }


### PR DESCRIPTION
I've added a comment that was requested [here](https://github.com/FluffyLabs/typeberry/pull/76/files#r1706934529) but PR was merged 🤷 