### PR TITLE
PVM: move math operations to a separate file

### DIFF
--- a/packages/pvm/ops/math-ops.ts
+++ b/packages/pvm/ops/math-ops.ts
@@ -1,12 +1,12 @@
 import type { Registers } from "../registers";
 import { MAX_VALUE, MIN_VALUE } from "./math-consts";
-import { add, mulUnsigned, mulUpperSigned, mulUpperUnsigned, sub } from "./math-utils";
+import { add, mulLowerUnsigned, mulUpperSigned, mulUpperUnsigned, sub } from "./math-utils";
 
 export class MathOps {
   constructor(private regs: Registers) {}
 
   add(firstIndex: number, secondIndex: number, resultIndex: number) {
-    this.addImmediate(firstIndex, this.regs.asUnsigned[secondIndex], resultIndex);
+    this.regs.asUnsigned[resultIndex] = add(this.regs.asUnsigned[firstIndex], this.regs.asUnsigned[secondIndex]);
   }
 
   addImmediate(firstIndex: number, immediateValue: number, resultIndex: number) {
@@ -14,23 +14,29 @@ export class MathOps {
   }
 
   mul(firstIndex: number, secondIndex: number, resultIndex: number) {
-    this.mulImmediate(firstIndex, this.regs.asUnsigned[secondIndex], resultIndex);
+    this.regs.asUnsigned[resultIndex] = mulLowerUnsigned(
+      this.regs.asUnsigned[firstIndex],
+      this.regs.asUnsigned[secondIndex],
+    );
   }
 
   mulUpperUU(firstIndex: number, secondIndex: number, resultIndex: number) {
-    this.mulUpperUUImmediate(firstIndex, this.regs.asUnsigned[secondIndex], resultIndex);
+    this.regs.asUnsigned[resultIndex] = mulUpperUnsigned(
+      this.regs.asUnsigned[firstIndex],
+      this.regs.asUnsigned[secondIndex],
+    );
   }
 
   mulUpperSS(firstIndex: number, secondIndex: number, resultIndex: number) {
-    this.mulUpperSSImmediate(firstIndex, this.regs.asSigned[secondIndex], resultIndex);
+    this.regs.asSigned[resultIndex] = mulUpperSigned(this.regs.asSigned[firstIndex], this.regs.asSigned[secondIndex]);
   }
 
   mulUpperSU(firstIndex: number, secondIndex: number, resultIndex: number) {
-    this.mulUpperSSImmediate(firstIndex, this.regs.asUnsigned[secondIndex], resultIndex);
+    this.regs.asSigned[resultIndex] = mulUpperSigned(this.regs.asSigned[firstIndex], this.regs.asUnsigned[secondIndex]);
   }
 
   mulImmediate(firstIndex: number, immediateValue: number, resultIndex: number) {
-    this.regs.asUnsigned[resultIndex] = mulUnsigned(this.regs.asUnsigned[firstIndex], immediateValue);
+    this.regs.asUnsigned[resultIndex] = mulLowerUnsigned(this.regs.asUnsigned[firstIndex], immediateValue);
   }
 
   mulUpperSSImmediate(firstIndex: number, immediateValue: number, resultIndex: number) {
@@ -42,7 +48,7 @@ export class MathOps {
   }
 
   sub(firstIndex: number, secondIndex: number, resultIndex: number) {
-    this.negAddImmediate(firstIndex, this.regs.asUnsigned[secondIndex], resultIndex);
+    this.regs.asUnsigned[resultIndex] = sub(this.regs.asUnsigned[firstIndex], this.regs.asUnsigned[secondIndex]);
   }
 
   negAddImmediate(firstIndex: number, immediateValue: number, resultIndex: number) {

--- a/packages/pvm/ops/math-utils.test.ts
+++ b/packages/pvm/ops/math-utils.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 
 import { MAX_VALUE } from "./math-consts";
-import { add, mulUnsigned, mulUpperSigned, mulUpperUnsigned, sub } from "./math-utils";
+import { add, mulLowerUnsigned, mulUpperSigned, mulUpperUnsigned, sub } from "./math-utils";
 
 describe("math-utils", () => {
   describe("add", () => {
@@ -75,7 +75,7 @@ describe("math-utils", () => {
       const b = 6;
       const expectedResult = 30;
 
-      const result = mulUnsigned(a, b);
+      const result = mulLowerUnsigned(a, b);
 
       assert.strictEqual(result, expectedResult);
     });
@@ -85,7 +85,7 @@ describe("math-utils", () => {
       const b = 2 ** 18;
       const expectedResult = 262144;
 
-      const result = mulUnsigned(a, b);
+      const result = mulLowerUnsigned(a, b);
 
       assert.strictEqual(result, expectedResult);
     });

--- a/packages/pvm/ops/math-utils.ts
+++ b/packages/pvm/ops/math-utils.ts
@@ -40,7 +40,7 @@ const MUL_THRESHOLD = 2 ** 16;
 
 /**
  * Efficiently multiply the two given numbers modulo 2**32 (i.e. lower 32-bit part of the multiplication).
- * 
+ *
  * In case the numbers fit into 2**32 we simply calculate their multiplication.
  * In case the numbers are larger we split them into higher and lower bits
  * and perform the multiplication separately to make sure we don't overflow


### PR DESCRIPTION
# What?

- I moved part of math operations from `math-ops.ts` to `math-utils.ts`. At the beginning I want to move all of them but unfortunately signed division has to have access to registers (in different cases  the result can be signed or unsigned)
- I fixed add operation. The previous solution didn't work
- I got rid of BigInt as it is slow. It resolves one of the problems described here: https://github.com/FluffyLabs/typeberry/issues/13

# Why?
I want to reuse safe `add` in other places (i.e. indirect addressing)
 