### PR TITLE
PVM - bunch of fixes 

### DIFF
--- a/packages/pvm/args-decoder/args-decoder.test.ts
+++ b/packages/pvm/args-decoder/args-decoder.test.ts
@@ -23,7 +23,7 @@ describe("ArgsDecoder", () => {
 
   it("return correct result for instruction with 1 immediate", () => {
     const code = new Uint8Array([Instruction.ECALLI, 0xff]);
-    const mask = new Mask(new Uint8Array([0b1111_1111]));
+    const mask = new Mask(new Uint8Array([0b1111_1101]));
     const argsDecoder = new ArgsDecoder(code, mask);
     const expectedImmediateDecoder = new ImmediateDecoder();
     expectedImmediateDecoder.setBytes(new Uint8Array([0xff]));
@@ -99,7 +99,7 @@ describe("ArgsDecoder", () => {
 
   it("return correct result for instruction with 1 reg, 1 immediate and 1 offset", () => {
     const code = new Uint8Array([Instruction.BRANCH_EQ_IMM, 39, 210, 4, 6]);
-    const mask = new Mask(new Uint8Array([0b1111_1001]));
+    const mask = new Mask(new Uint8Array([0b1110_0001]));
     const argsDecoder = new ArgsDecoder(code, mask);
     const expectedImmediateDecoder = new ImmediateDecoder();
     expectedImmediateDecoder.setBytes(new Uint8Array([210, 4]));

--- a/packages/pvm/args-decoder/args-decoder.ts
+++ b/packages/pvm/args-decoder/args-decoder.ts
@@ -166,7 +166,7 @@ export class ArgsDecoder {
         const firstByte = this.code[pc + 1];
         this.nibblesDecoder.setByte(firstByte);
         result.firstRegisterIndex = this.nibblesDecoder.getLowNibbleAsRegisterIndex();
-        const immediateLength = this.nibblesDecoder.getHighNibble();
+        const immediateLength = this.nibblesDecoder.getHighNibbleAsLength();
         result.immediateDecoder.setBytes(this.code.subarray(pc + 2, pc + 2 + immediateLength));
         const offsetLength = this.mask.getNoOfBytesToNextInstruction(pc + 2 + immediateLength);
         this.offsetDecoder.setBytes(

--- a/packages/pvm/basic-blocks/basic-blocks.test.ts
+++ b/packages/pvm/basic-blocks/basic-blocks.test.ts
@@ -50,6 +50,17 @@ describe("BasicBlocks", () => {
     assert.strictEqual(result, false);
   });
 
+  it("should return true for a beginning of basic block instruction that is not the first instruction after a block termination instruction that has some args", () => {
+    const mask = new Mask(new Uint8Array([0b1100_1001]));
+    const code = new Uint8Array([Instruction.BRANCH_EQ, 135, 25, Instruction.ADD, 5, 7, Instruction.TRAP]);
+    const basicBlocks = new BasicBlocks(code, mask);
+    const index = 3;
+
+    const result = basicBlocks.isBeginningOfBasicBlock(index);
+
+    assert.strictEqual(result, true);
+  });
+
   it("should return true for a termination block instruction that is the after a termination instruction", () => {
     const mask = new Mask(new Uint8Array([0b1111_1111]));
     const code = new Uint8Array([Instruction.TRAP, Instruction.TRAP]);

--- a/packages/pvm/basic-blocks/basic-blocks.ts
+++ b/packages/pvm/basic-blocks/basic-blocks.ts
@@ -11,8 +11,10 @@ export class BasicBlocks {
     if (index === 0) {
       return true;
     }
-
-    return this.mask.isInstruction(index) && this.isBasicBlockTermination(index - 1);
+    return (
+      this.mask.isInstruction(index) &&
+      this.isBasicBlockTermination(index - (this.mask.getNoOfBytesToPreviousInstruction(index - 1) + 1))
+    );
   }
 
   private isBasicBlockTermination(index: number) {

--- a/packages/pvm/program-decoder/mask.test.ts
+++ b/packages/pvm/program-decoder/mask.test.ts
@@ -53,17 +53,6 @@ describe("Mask", () => {
   describe("getNoOfBytesToNextInstruction", () => {
     it("should return number of 0s between two 1 in single byte", () => {
       const input = [0b1111_1001];
-      const index = 0;
-      const expectedResult = 3;
-      const mask = new Mask(new Uint8Array(input));
-
-      const result = mask.getNoOfBytesToNextInstruction(index);
-
-      assert.strictEqual(result, expectedResult);
-    });
-
-    it("should return number of 0s from current index (that is 1) to next 1", () => {
-      const input = [0b1111_1001];
       const index = 1;
       const expectedResult = 2;
       const mask = new Mask(new Uint8Array(input));
@@ -73,10 +62,21 @@ describe("Mask", () => {
       assert.strictEqual(result, expectedResult);
     });
 
+    it("should return 0 if the bit value is 1", () => {
+      const input = [0b1111_1001];
+      const index = 0;
+      const expectedResult = 0;
+      const mask = new Mask(new Uint8Array(input));
+
+      const result = mask.getNoOfBytesToNextInstruction(index);
+
+      assert.strictEqual(result, expectedResult);
+    });
+
     it("should return number of 0s between two 1 in 2 bytes", () => {
       const input = [0b0001_1001, 0b0001_1000];
-      const index = 4;
-      const expectedResult = 7;
+      const index = 5;
+      const expectedResult = 6;
       const mask = new Mask(new Uint8Array(input));
 
       const result = mask.getNoOfBytesToNextInstruction(index);
@@ -86,11 +86,46 @@ describe("Mask", () => {
 
     it("should return number of 0s between to the end", () => {
       const input = [0b0001_1001];
-      const index = 4;
-      const expectedResult = 4;
+      const index = 5;
+      const expectedResult = 3;
       const mask = new Mask(new Uint8Array(input));
 
       const result = mask.getNoOfBytesToNextInstruction(index);
+
+      assert.strictEqual(result, expectedResult);
+    });
+  });
+
+  describe("getNoOfBytesToPreviousInstruction", () => {
+    it("should return number of 0s between two 1 in single byte", () => {
+      const input = [0b1111_1001];
+      const index = 2;
+      const expectedResult = 2;
+      const mask = new Mask(new Uint8Array(input));
+
+      const result = mask.getNoOfBytesToPreviousInstruction(index);
+
+      assert.strictEqual(result, expectedResult);
+    });
+
+    it("should return 0 if the bit value is 1", () => {
+      const input = [0b1111_1001];
+      const index = 3;
+      const expectedResult = 0;
+      const mask = new Mask(new Uint8Array(input));
+
+      const result = mask.getNoOfBytesToPreviousInstruction(index);
+
+      assert.strictEqual(result, expectedResult);
+    });
+
+    it("should return number of 0s between two 1 in 2 bytes", () => {
+      const input = [0b0001_1001, 0b0001_1000];
+      const index = 10;
+      const expectedResult = 6;
+      const mask = new Mask(new Uint8Array(input));
+
+      const result = mask.getNoOfBytesToPreviousInstruction(index);
 
       assert.strictEqual(result, expectedResult);
     });

--- a/packages/pvm/program-decoder/mask.ts
+++ b/packages/pvm/program-decoder/mask.ts
@@ -1,3 +1,4 @@
+import { check } from "@typeberry/utils";
 export class Mask {
   /**
    * The lookup table will have `0` at the index which corresponds to an instruction on the same index in the bytecode.
@@ -6,29 +7,36 @@ export class Mask {
    * Example:
    * ```
    * 0..1..2..3..4..5..6..7..8..9 # Indices
-   * 0..2..1..0..1..0..3..2..1..0 # lookupTable values
+   * 0..2..1..0..1..0..3..2..1..0 # lookupTable forward values
+   * 0..1..2..0..1..0..1..2..3..0 # lookupTable backward values
    * ```
    * There are instructions at indices `0, 3, 5, 9`.
    */
-  private lookupTable: Uint8Array;
+  private lookupTableForward: Uint8Array;
+  private lookupTableBackward: Uint8Array;
 
   constructor(mask: Uint8Array) {
-    this.lookupTable = this.buildLookupTable(mask);
+    this.lookupTableForward = this.buildLookupTableForward(mask);
+    this.lookupTableBackward = this.buildLookupTableBackward(mask);
   }
 
   isInstruction(index: number) {
-    return this.lookupTable[index] === 0;
+    return this.lookupTableForward[index] === 0;
   }
 
   getNoOfBytesToNextInstruction(index: number) {
-    if (this.isInstruction(index)) {
-      const nextIndex = Math.min(index + 1, this.lookupTable.length - 1);
-      return this.lookupTable[nextIndex] + 1;
-    }
-    return this.lookupTable[index];
+    check(index >= 0, "index cannot be a negative number");
+    check(index < this.lookupTableForward.length, `index cannot be bigger than ${this.lookupTableForward.length}`);
+    return this.lookupTableForward[index];
   }
 
-  private buildLookupTable(mask: Uint8Array) {
+  getNoOfBytesToPreviousInstruction(index: number) {
+    check(index >= 0, "index cannot be a negative number");
+    check(index < this.lookupTableBackward.length, `index cannot be bigger than ${this.lookupTableBackward.length}`);
+    return this.lookupTableBackward[index];
+  }
+
+  private buildLookupTableForward(mask: Uint8Array) {
     const table = new Uint8Array(mask.length * 8);
     let lastInstructionOffset = 0;
     for (let i = mask.length - 1; i >= 0; i--) {
@@ -41,6 +49,24 @@ export class Mask {
         }
         table[i * 8 + j] = lastInstructionOffset;
         singleBitMask >>>= 1;
+      }
+    }
+    return table;
+  }
+
+  private buildLookupTableBackward(mask: Uint8Array) {
+    const table = new Uint8Array(mask.length * 8);
+    let lastInstructionOffset = 0;
+    for (let i = 0; i < mask.length; i++) {
+      let singleBitMask = 0x01;
+      for (let j = 0; j < 8; j++) {
+        if ((mask[i] & singleBitMask) > 0) {
+          lastInstructionOffset = 0;
+        } else {
+          lastInstructionOffset++;
+        }
+        table[i * 8 + j] = lastInstructionOffset;
+        singleBitMask <<= 1;
       }
     }
     return table;


### PR DESCRIPTION
# What?
Fibonacci sequence program showed a few problems in PVM:
- immediates that have length equal to 0 are parsed incorrectly (this case wasn't handled)
- jump destination is validated incorrectly (previous byte was validated instead of previous instruction)

Those problems are fixed by this PR.

# How?

## immediates with length 0

I changed implementation of `getNoOfBytesToNextInstruction(index: number)`: 
- before: it returns number of bytes to next instruction in case of `code[index]` is an instruction
- after: it returns `0` if `code[index]` is an instruction

## jump validation

Here I made a mistake during implementation and I validated the previous byte what was completely incorrect. To fix that I had to add `getNoOfBytesToPreviousInstruction(index: number)` and build backward lookup table.  
