### PR TITLE
Run benchmarks only if it is necessary

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,7 @@ name: Benchmarks
 on:
   pull_request:
     branches: ["main"]
+    paths: ['.github/workflows/benchmarks.yml', 'benchmarks/**', 'tools/benchmark/**']
 
 jobs:
   benchmarks:


### PR DESCRIPTION
# What? 
This PR disables the benchamark runner in case if there no changes in `benchmarks`, `tools/benchmark` or `benchmarks.yml` 

# Why?
It does not make any sense to run it if we change nothing that is able to affect results 

