### PR TITLE
PVM: export memory 

### DIFF
--- a/packages/pvm/index.ts
+++ b/packages/pvm/index.ts
@@ -1,1 +1,2 @@
 export * from "./pvm";
+export { Memory, MemoryBuilder } from "./memory";


### PR DESCRIPTION
# What? 
I exported `Memory` and `MemoryBuilder` from PVM

# Why?
PVM is built as commonjs and I cannot access those classes without exporting them from the main file. I need them to initialize memory in pvm debugger