### PR TITLE
Run benchmarks on schedule.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["main"]
     paths: ['.github/workflows/benchmarks.yml', 'benchmarks/**', 'tools/benchmark/**']
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   benchmarks:


### PR DESCRIPTION
I fixed the GHA runner now, and since benchmarks now only run when they are changed (vide #93) I'm fearing that they might simply break at some point and we will not even notice, hence I'd prefer them running daily.