### PR TITLE
Fix benchmarks.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,7 +31,7 @@ jobs:
         if: always()
         run: echo './benchmarks/results.txt'
       - name: Comment PR
-        if: github.event_name !== 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: ./benchmarks/results.txt


### PR DESCRIPTION
Turns out that `!==` makes the workflow invalid :) The condition has to be `!=`.