### PR TITLE
PVM: add pvm-debugger-adapter package to workflow triggers

### DIFF
--- a/.github/workflows/publish-pvm.yml
+++ b/.github/workflows/publish-pvm.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    paths: ['packages/pvm/**', 'packages/pvm-debugger-adapter/**']
+    paths: ['packages/pvm/**', 'packages/pvm-debugger-adapter/**', '.github/workflows/publish-pvm.yml']
 jobs:
   publish-pvm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What?
PVM wasn't recently published because we didn't make any changes in `packages/pvm` and `packages/pvm-debugger-adapter` doesn't trigger the workflow. I fixed this problem

https://www.npmjs.com/package/@typeberry/pvm?activeTab=versions