### PR TITLE
Unify test-runner & benchmarks comments.

### DIFF
--- a/bin/test-runner/reporter.ts
+++ b/bin/test-runner/reporter.ts
@@ -44,6 +44,7 @@ function myTransform(this: Reporter, event: TestEvent, _encoding: BufferEncoding
           null,
           `
 <details>
+<summary>View all</summary>
 
 |  Name  |  Status  | |
 |--------|----------|-|

--- a/tools/benchmark/format.ts
+++ b/tools/benchmark/format.ts
@@ -52,11 +52,11 @@ export function formatResults(input: Map<string, Result>, commitHash?: string) {
   const detailsTxt = formatDetails(all);
   const errorsTxt = formatErrors(errors);
   return `
-### Benchmarks summary: ${okCount}/${all.length} OK ${okCount === all.length ? "✅" : "❌"}
+${errorsTxt}
 
 ${detailsTxt}
 
-${errorsTxt}
+### Benchmarks summary: ${okCount}/${all.length} OK ${okCount === all.length ? "✅" : "❌"}
 `;
 }
 


### PR DESCRIPTION
I was kind of annoyed that there is no "View all" for JAM test vectors and that the benchmarks vs tests are displayed differently in the comments.

For simplicity we need to display "View all" before the summary in tests (otherwise we would need to buffer everything and only output at the very end), so I decided to display benchmarks in the same way.