### PR TITLE
Export utils to use in PVM debugger

### DIFF
--- a/packages/pvm-debugger-adapter/index.ts
+++ b/packages/pvm-debugger-adapter/index.ts
@@ -1,2 +1,5 @@
 export { Memory, MemoryBuilder } from "@typeberry/pvm";
 export { PvmDebuggerAdapter as Pvm } from "./pvm-debugger-adapter";
+export { ProgramDecoder } from "@typeberry/pvm/program-decoder/program-decoder";
+export { ArgsDecoder } from "@typeberry/pvm/args-decoder/args-decoder";
+export { ArgumentType } from "@typeberry/pvm/args-decoder/argument-type";


### PR DESCRIPTION
I exported a few utils to avoid copy-pasting them to our debugger