### PR TITLE
export Registers class and new PVM methods (reset and resume) from debugger adapter

### DIFF
--- a/packages/pvm-debugger-adapter/index.ts
+++ b/packages/pvm-debugger-adapter/index.ts
@@ -6,3 +6,4 @@ export { ArgumentType } from "@typeberry/pvm/args-decoder/argument-type";
 export { createResults } from "@typeberry/pvm/args-decoder/args-decoding-results";
 export { instructionArgumentTypeMap } from "@typeberry/pvm/args-decoder/instruction-argument-type-map";
 export { decodeStandardProgram } from "../pvm-standard-program-decoder";
+export { Registers } from "@typeberry/pvm/registers";

--- a/packages/pvm-debugger-adapter/pvm-debugger-adapter.ts
+++ b/packages/pvm-debugger-adapter/pvm-debugger-adapter.ts
@@ -1,5 +1,6 @@
-import { Pvm } from "@typeberry/pvm";
+import { type Memory, Pvm } from "@typeberry/pvm";
 import { PAGE_SIZE } from "@typeberry/pvm/memory/memory-consts";
+import type { Registers } from "@typeberry/pvm/registers";
 
 export class PvmDebuggerAdapter {
   private pvm: Pvm;
@@ -26,6 +27,14 @@ export class PvmDebuggerAdapter {
 
   getStatus() {
     return this.pvm.getStatus();
+  }
+
+  reset(rawProgram: Uint8Array, pc: number, gas: number, maybeRegisters?: Registers, maybeMemory?: Memory) {
+    this.pvm.reset(rawProgram, pc, gas, maybeRegisters, maybeMemory);
+  }
+
+  resume(nextPc: number, gas: number) {
+    this.pvm.resume(nextPc, gas);
   }
 
   getMemoryPage(pageNumber: number): null | Uint8Array {


### PR DESCRIPTION
I had to export a few things to use in our debugger because of the last changes connected with host calls 