### PR TITLE
Changed benchmark trigger to pull_request_target

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,7 +4,7 @@ name: Benchmarks
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches: ["main"]
   schedule:
     - cron: '45 4 * * *'


### PR DESCRIPTION
The goal is to allow the benchmarks action to post comments in PRs opened from a fork.

The reasoning behind this comes from the readme of https://github.com/thollander/actions-comment-pull-request:

>Note that, if the PR comes from a fork, it will have only read permission despite the permissions given in the action for the pull_request event. In this case, you may use the pull_request_target event. With this event, permissions can be given without issue (the difference is that it will execute the action from the target branch and not from the origin PR).

As well as from the following answer at stack overflow:
https://stackoverflow.com/a/74959635