### PR TITLE
Updated comment condition in benchmark workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,7 +37,7 @@ jobs:
         if: always()
         run: cat ./dist/benchmarks/results.txt
       - name: Comment PR
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request_target'
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: ./dist/benchmarks/results.txt


### PR DESCRIPTION
The comment condition in the benchmark workflow was updated to include the `pull_request_target` event