### PR TITLE
ArgsDecoder - GP alignment

### DIFF
--- a/packages/pvm/interpreter/args-decoder/decoders/extended-with-immediate-decoder.ts
+++ b/packages/pvm/interpreter/args-decoder/decoders/extended-with-immediate-decoder.ts
@@ -1,5 +1,3 @@
-import { check } from "@typeberry/utils";
-
 const IMMEDIATE_SIZE = 8;
 
 export class ExtendedWitdthImmediateDecoder {
@@ -13,13 +11,13 @@ export class ExtendedWitdthImmediateDecoder {
   }
 
   setBytes(bytes: Uint8Array) {
-    check(
-      bytes.length === 8,
-      `Extended width immadiate has to have length that is equal to 8 but got: ${bytes.length}`,
-    );
-
-    for (let i = 0; i < IMMEDIATE_SIZE; i++) {
+    let i = 0;
+    for (; i < bytes.length; i++) {
       this.bytes[i] = bytes[i];
+    }
+
+    for (; i < IMMEDIATE_SIZE; i++) {
+      this.bytes[i] = 0;
     }
   }
 

--- a/packages/pvm/interpreter/args-decoder/parsing-args-error.ts
+++ b/packages/pvm/interpreter/args-decoder/parsing-args-error.ts
@@ -1,5 +1,0 @@
-export class ParsingArgsError extends Error {
-  constructor() {
-    super("Incorrect arguments length");
-  }
-}

--- a/packages/pvm/interpreter/interpreter.ts
+++ b/packages/pvm/interpreter/interpreter.ts
@@ -176,9 +176,9 @@ export class Interpreter {
     }
     const argsType = instructionArgumentTypeMap[currentInstruction] ?? ArgumentType.NO_ARGUMENTS;
     const argsResult = this.argsDecodingResults[argsType];
-    const parsingArgsResult = this.argsDecoder.fillArgs(this.pc, argsResult);
+    this.argsDecoder.fillArgs(this.pc, argsResult);
 
-    if (parsingArgsResult !== null || !isValidInstruction) {
+    if (!isValidInstruction) {
       this.instructionResult.status = Result.PANIC;
     } else {
       this.instructionResult.nextPc = this.pc + argsResult.noOfBytesToSkip;


### PR DESCRIPTION
# Changes: 
- removed arguments validation 
- in the middle of program - if the instruction doesn't have enough arguments then next bytes (if exist) are read as arguments
- missing arguments at the end of code (the last instruction) are padded with 0s 
