### PR TITLE
Fix sign extend 

### DIFF
--- a/packages/pvm/interpreter/ops/bit-ops.test.ts
+++ b/packages/pvm/interpreter/ops/bit-ops.test.ts
@@ -353,6 +353,16 @@ describe("BitOps", () => {
 
       assert.strictEqual(regs.getI64(resultRegisterIndex), resultValue);
     });
+
+    it("should extend sign but should not change the least significant 8 bits", () => {
+      const value = 0x00006d6d6d6dd48dn;
+      const resultValue = 0xffffffffffffff8dn;
+      const { bitOps, regs, firstRegisterIndex, resultRegisterIndex } = prepareData(value);
+
+      bitOps.signExtend8(firstRegisterIndex, resultRegisterIndex);
+
+      assert.strictEqual(regs.getU64(resultRegisterIndex), resultValue);
+    });
   });
 
   describe("signExtend16", () => {
@@ -374,6 +384,16 @@ describe("BitOps", () => {
       bitOps.signExtend16(firstRegisterIndex, resultRegisterIndex);
 
       assert.strictEqual(regs.getI64(resultRegisterIndex), resultValue);
+    });
+
+    it("should extend sign but should not change the least significant 16 bits", () => {
+      const value = 0x00006d6d6d6dd46dn;
+      const resultValue = 0xffffffffffffd46dn;
+      const { bitOps, regs, firstRegisterIndex, resultRegisterIndex } = prepareData(value);
+
+      bitOps.signExtend16(firstRegisterIndex, resultRegisterIndex);
+
+      assert.strictEqual(regs.getU64(resultRegisterIndex), resultValue);
     });
   });
 

--- a/packages/pvm/interpreter/ops/bit-ops.ts
+++ b/packages/pvm/interpreter/ops/bit-ops.ts
@@ -71,7 +71,7 @@ export class BitOps {
     const bitSign = 1 << (length - 1);
 
     if ((maskedValue & bitSign) > 0) {
-      return ~BigInt(maskedValue) + 1n;
+      return ~BigInt(mask) | BigInt(maskedValue);
     }
 
     return BigInt(maskedValue);


### PR DESCRIPTION
The sign was extended incorrectly - it was `x *= -1` instead of `x |= 0xff..ff`  