### PR TITLE
memory builder - fix boundaries

### DIFF
--- a/packages/pvm/interpreter/memory/memory-builder.test.ts
+++ b/packages/pvm/interpreter/memory/memory-builder.test.ts
@@ -99,4 +99,28 @@ describe("MemoryBuilder", () => {
       assert.deepEqual(memory, expectedMemory);
     });
   });
+
+  describe("setData", () => {
+    it("should add writeable page and set data separately", () => {
+      const builder = new MemoryBuilder();
+      const pageMap = new Map();
+      const data = new Uint8Array(PAGE_SIZE).fill(1);
+      const pageNumber = tryAsPageNumber(2);
+      const address = tryAsMemoryIndex(pageNumber * PAGE_SIZE);
+      pageMap.set(pageNumber, new WriteablePage(pageNumber, data));
+      const expectedMemory = {
+        endHeapIndex: 4 * PAGE_SIZE,
+        sbrkIndex: 3 * PAGE_SIZE,
+        virtualSbrkIndex: 3 * PAGE_SIZE,
+        memory: pageMap,
+      };
+
+      const memory = builder
+        .setWriteablePages(tryAsMemoryIndex(2 * PAGE_SIZE), tryAsMemoryIndex(3 * PAGE_SIZE))
+        .setData(address, data)
+        .finalize(tryAsSbrkIndex(3 * PAGE_SIZE), tryAsSbrkIndex(4 * PAGE_SIZE));
+
+      assert.deepEqual(memory, expectedMemory);
+    });
+  });
 });

--- a/packages/pvm/interpreter/memory/memory-builder.ts
+++ b/packages/pvm/interpreter/memory/memory-builder.ts
@@ -82,8 +82,9 @@ export class MemoryBuilder {
    */
   setData(start: MemoryIndex, data: Uint8Array) {
     this.ensureNotFinalized();
-    const end = tryAsMemoryIndex(start + data.length);
-    check(getPageNumber(start) === getPageNumber(end), "The data has to fit into a single page.");
+    const pageOffset = start % PAGE_SIZE;
+    const remainingSpaceOnPage = PAGE_SIZE - pageOffset;
+    check(data.length <= remainingSpaceOnPage, "The data has to fit into a single page.");
     const pageNumber = getPageNumber(start);
     const page = this.initialMemory.get(pageNumber);
 

--- a/packages/pvm/interpreter/memory/pages/writeable-page.ts
+++ b/packages/pvm/interpreter/memory/pages/writeable-page.ts
@@ -57,6 +57,10 @@ export class WriteablePage extends MemoryPage {
   }
 
   setData(pageIndex: PageIndex, data: Uint8Array) {
+    if (this.buffer.byteLength < pageIndex + data.length && this.buffer.byteLength < PAGE_SIZE) {
+      const newLength = Math.min(PAGE_SIZE, Math.max(MIN_ALLOCATION_LENGTH, pageIndex + data.length));
+      this.buffer.resize(newLength);
+    }
     this.view.set(data, pageIndex);
   }
 


### PR DESCRIPTION
I fixed two problems in `setData` (`MemoryBuilder`):
1. boundaries (reported [here](https://github.com/FluffyLabs/pvm-debugger/pull/293/files#diff-995927527ad0830b7d0317ec2763b71049245855e5eacc2444862ec42509e008R30))
2. added logic to resize memory builder when data length is longer than the current size