### PR TITLE
Updating links to the newest version.

### DIFF
--- a/packages/block/assurances.ts
+++ b/packages/block/assurances.ts
@@ -14,7 +14,7 @@ import type { HeaderHash } from "./hash";
  * A work-report is said to become available iff there are a clear
  * 2/3 supermajority of validators who have marked its core as set within
  * the block's assurance extrinsic.
- * https://graypaper.fluffylabs.dev/#/c71229b/135201135601
+ * https://graypaper.fluffylabs.dev/#/579bd12/145800145c00
  */
 export class AvailabilityAssurance extends WithDebug {
   static Codec = codec.Class(AvailabilityAssurance, {
@@ -39,7 +39,7 @@ export class AvailabilityAssurance extends WithDebug {
   constructor(
     /**
      * The assurances must all be anchored on the parent.
-     * https://graypaper.fluffylabs.dev/#/c71229b/135201135601
+     * https://graypaper.fluffylabs.dev/#/579bd12/145800145c00
      */
     public readonly anchor: HeaderHash,
     /**
@@ -62,7 +62,7 @@ export class AvailabilityAssurance extends WithDebug {
  * `E_A`: Sequence with at most one item per validator.
  *
  * Assurances must be ordered by validator index.
- * https://graypaper.fluffylabs.dev/#/c71229b/135201135601
+ * https://graypaper.fluffylabs.dev/#/579bd12/145800145c00
  */
 export type AssurancesExtrinsic = KnownSizeArray<AvailabilityAssurance, "0 .. ValidatorsCount">;
 

--- a/packages/block/block.ts
+++ b/packages/block/block.ts
@@ -12,7 +12,7 @@ import { type TicketsExtrinsic, ticketsExtrinsicCodec } from "./tickets";
  *
  * `E = (E_T, E_D, E_P, E_A, E_G)`
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/08ab0008ab00
+ * https://graypaper.fluffylabs.dev/#/579bd12/08ab0008ab00
  */
 export class Extrinsic extends WithDebug {
   static Codec = codec.Class(Extrinsic, {
@@ -65,7 +65,7 @@ export type ExtrinsicView = DescribedBy<typeof Extrinsic.Codec.View>;
  * The block consists of the header and some external input data (extrinsic).
  *
  * `B = (H, E)`
- * https://graypaper.fluffylabs.dev/#/c71229b/089900089900
+ * https://graypaper.fluffylabs.dev/#/579bd12/089900089900
  */
 export class Block extends WithDebug {
   static Codec = codec.Class(Block, {

--- a/packages/block/common.ts
+++ b/packages/block/common.ts
@@ -7,7 +7,7 @@ import { type Opaque, asOpaqueType } from "@typeberry/utils";
  *
  * "an index of a six-second timeslots from the JAM Common Era"
  *
- * https://graypaper.fluffylabs.dev/#/387103d/0b1d000b2100
+ * https://graypaper.fluffylabs.dev/#/579bd12/0b46000b4a00
  */
 export type TimeSlot = Opaque<U32, "TimeSlot[u32]">;
 /** Attempt to convert a number into `TimeSlot`. */
@@ -41,7 +41,7 @@ export type StateRootHash = Opaque<OpaqueHash, "StateRootHash">;
 /**
  * Index of an epoch.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/0b20000b2300
+ * https://graypaper.fluffylabs.dev/#/579bd12/0b39000b3c00
  */
 export type Epoch = Opaque<U32, "Epoch">;
 /** Attempt to convert a number into `Epoch`. */

--- a/packages/block/crypto.ts
+++ b/packages/block/crypto.ts
@@ -18,41 +18,41 @@ export type BLS_KEY_BYTES = typeof BLS_KEY_BYTES;
 /**
  * Potentially valid Ed25519 public key.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/081200081b00
+ * https://graypaper.fluffylabs.dev/#/579bd12/081300081a00
  */
 export type Ed25519Key = Opaque<Bytes<ED25519_KEY_BYTES>, "Ed25519Key">;
 
 /**
  * Potentially valid Ed25519 signature.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/081200081b00
+ * https://graypaper.fluffylabs.dev/#/579bd12/081300081a00
  */
 export type Ed25519Signature = Opaque<Bytes<ED25519_SIGNATURE_BYTES>, "Ed25519Signature">;
 
 /**
  * Potentially valid Bandersnatch public key.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/082200082400
+ * https://graypaper.fluffylabs.dev/#/579bd12/082200082200
  */
 export type BandersnatchKey = Opaque<Bytes<BANDERSNATCH_KEY_BYTES>, "BandersnatchKey">;
 
 /**
  * Potentially valid Bandersnatch signature.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/082200082400
+ * https://graypaper.fluffylabs.dev/#/579bd12/082200082200
  */
 export type BandersnatchVrfSignature = Opaque<Bytes<BANDERSNATCH_VRF_SIGNATURE_BYTES>, "BandersnatchVrfSignature">;
 
 /**
  * Potentially valid Bandersnatch RingVRF proof of knowledge.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/082d00083a00
+ * https://graypaper.fluffylabs.dev/#/579bd12/082d00083a00
  */
 export type BandersnatchProof = Opaque<Bytes<BANDERSNATCH_PROOF_BYTES>, "BandersnatchRingSignature">;
 
 /**
  * A public key for BLS signature scheme
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/081c00082100
+ * https://graypaper.fluffylabs.dev/#/579bd12/081c00081c00
  */
 export type BlsKey = Opaque<Bytes<BLS_KEY_BYTES>, "BlsKey">;

--- a/packages/block/disputes.ts
+++ b/packages/block/disputes.ts
@@ -94,7 +94,7 @@ export class Judgement extends WithDebug {
  * (either using keys from current epoch or previous)
  * over validity or invalidity of a particular [`WorkReport`].
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/12af0012af00
+ * https://graypaper.fluffylabs.dev/#/579bd12/12cd0012cd00
  */
 export class Verdict extends WithDebug {
   static Codec = codec.Class(Verdict, {
@@ -128,10 +128,10 @@ export class Verdict extends WithDebug {
      * Votes coming from super majority of validators.
      *
      * NOTE: must be ordered by validator index.
-     * https://graypaper.fluffylabs.dev/#/c71229b/121802121902
+     * https://graypaper.fluffylabs.dev/#/579bd12/123702123802
      *
      * TODO [ToDr] The Gray Paper does not seem to imply that this has to be
-     * supermajority: https://graypaper.fluffylabs.dev/#/c71229b/123202123702 ?
+     * supermajority: https://graypaper.fluffylabs.dev/#/579bd12/124e02125502
      */
     public readonly votes: KnownSizeArray<Judgement, "Validators super majority">,
   ) {
@@ -146,7 +146,7 @@ export class Verdict extends WithDebug {
  *
  * `E_D = (v, c, f)`
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/115d01115d01
+ * https://graypaper.fluffylabs.dev/#/579bd12/124900124900
  */
 export class DisputesExtrinsic extends WithDebug {
   static Codec = codec.Class(DisputesExtrinsic, {
@@ -164,21 +164,21 @@ export class DisputesExtrinsic extends WithDebug {
      * `v`: a collection of verdicts over validity of some [`WorkReport`]s.
      *
      *  NOTE: must be ordered by report hash.
-     *  https://graypaper.fluffylabs.dev/#/c71229b/12a50112a501
+     *  https://graypaper.fluffylabs.dev/#/579bd12/12c40112c401
      */
     public readonly verdicts: Verdict[],
     /**
      * `c`: proofs of validator misbehavior: gauranteeing an invalid [`WorkReport`].
      *
      * NOTE: must be ordered by the validator's Ed25519Key.
-     * https://graypaper.fluffylabs.dev/#/c71229b/12a50112a701
+     * https://graypaper.fluffylabs.dev/#/579bd12/12c40112c601
      */
     public readonly culprits: Culprit[],
     /**
      * `c`: proofs of validator misbehavior: signing a contradictory judgement of a [`WorkReport`] validity.
      *
      * NOTE: must be ordered by the validator's Ed25519Key.
-     * https://graypaper.fluffylabs.dev/#/c71229b/12a50112a701
+     * https://graypaper.fluffylabs.dev/#/579bd12/12c40112c601
      */
     public readonly faults: Fault[],
   ) {

--- a/packages/block/gaurantees.ts
+++ b/packages/block/gaurantees.ts
@@ -29,7 +29,7 @@ export class Credential extends WithDebug {
 /**
  * Tuple of work-report, a credential and it's corresponding timeslot.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/142e02144e02
+ * https://graypaper.fluffylabs.dev/#/579bd12/147102149102
  */
 export class ReportGuarantee extends WithDebug {
   static Codec = codec.Class(ReportGuarantee, {
@@ -53,7 +53,7 @@ export class ReportGuarantee extends WithDebug {
      * validator index and a signature.
      * Credentials must be ordered by their validator index.
      *
-     * https://graypaper.fluffylabs.dev/#/c71229b/147602147802
+     * https://graypaper.fluffylabs.dev/#/579bd12/14b90214bb02
      */
     public readonly credentials: KnownSizeArray<Credential, "0..ValidatorsCount">,
   ) {
@@ -67,7 +67,7 @@ export class ReportGuarantee extends WithDebug {
  * Each core index (within work-report) must be unique and guarantees
  * must be in ascending order of this.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/142102142402
+ * https://graypaper.fluffylabs.dev/#/579bd12/146402146702
  */
 export type GuaranteesExtrinsic = KnownSizeArray<ReportGuarantee, "0..CoresCount">;
 

--- a/packages/block/gp-constants.ts
+++ b/packages/block/gp-constants.ts
@@ -11,7 +11,7 @@ import { MAX_NUMBER_OF_WORK_ITEMS } from "./work-package";
  * here are only temporarily for convenience. When we figure out better names
  * and places for these this file will be eradicated.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/3d22003d2200
+ * https://graypaper.fluffylabs.dev/#/579bd12/413000413000
  */
 
 /** `I`: Maximum number of work items in a package. */

--- a/packages/block/hash.ts
+++ b/packages/block/hash.ts
@@ -4,7 +4,7 @@ import type { Opaque } from "@typeberry/utils";
 /**
  * Blake2B hash of JAM-encoding of some header.
  *
- * https://graypaper.fluffylabs.dev/#/387103d/0c5f000c6300
+ * https://graypaper.fluffylabs.dev/#/579bd12/0c7b000c7e00
  */
 export type HeaderHash = Opaque<OpaqueHash, "HeaderHash">;
 
@@ -12,9 +12,9 @@ export type HeaderHash = Opaque<OpaqueHash, "HeaderHash">;
 export type WorkReportHash = Opaque<OpaqueHash, "WorkReportHash">;
 
 /**
- * Blake2B hash of JAM-encoding of all extrinsics concatenated.
+ * Blake2B merkle commitment to the block's extrinsic data.
  *
- * https://graypaper.fluffylabs.dev/#/387103d/0c84000c8d00
+ * https://graypaper.fluffylabs.dev/#/579bd12/0ca1000ca400
  */
 export type ExtrinsicHash = Opaque<OpaqueHash, "ExtrinsicHash">;
 

--- a/packages/block/header.ts
+++ b/packages/block/header.ts
@@ -29,7 +29,7 @@ import { Ticket } from "./tickets";
  * and contains the epoch randomness and Bandersnatch keys
  * of validators for the NEXT epoch.
  *
- * https://graypaper.fluffylabs.dev/#/911af30/0e30030e6903
+ * https://graypaper.fluffylabs.dev/#/579bd12/0e30030e6603
  */
 export class EpochMarker extends WithDebug {
   static Codec = codec.Class(EpochMarker, {
@@ -69,7 +69,7 @@ export class EpochMarker extends WithDebug {
 /**
  * The header of the JAM block.
  *
- * https://graypaper.fluffylabs.dev/#/387103d/0c48000c5400
+ * https://graypaper.fluffylabs.dev/#/579bd12/0c66000c7200
  */
 export class Header extends WithDebug {
   static Codec = codec.Class(Header, {
@@ -130,7 +130,7 @@ export class Header extends WithDebug {
   /**
    * `H_s`: Block seal.
    *
-   * https://graypaper.fluffylabs.dev/#/387103d/0de8000dee00
+   * https://graypaper.fluffylabs.dev/#/579bd12/0d0c010d1101
    */
   public seal: BandersnatchVrfSignature = Bytes.zero(BANDERSNATCH_VRF_SIGNATURE_BYTES).asOpaque();
 

--- a/packages/block/preimage.ts
+++ b/packages/block/preimage.ts
@@ -6,7 +6,7 @@ import type { ServiceId } from "./common";
 /**
  * Service index (requester) and the data (blob).
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/153801154901
+ * https://graypaper.fluffylabs.dev/#/579bd12/181500181600
  */
 export class Preimage extends WithDebug {
   static Codec = codec.Class(Preimage, {

--- a/packages/block/refine-context.ts
+++ b/packages/block/refine-context.ts
@@ -7,7 +7,7 @@ import type { HeaderHash } from "./hash";
 /**
  * Keccak-256 hash of the BEEFY MMR root.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/1e76001e7900
+ * https://graypaper.fluffylabs.dev/#/579bd12/1e4f011e5201
  */
 export type BeefyHash = Opaque<OpaqueHash, "BeefyHash">;
 
@@ -15,7 +15,7 @@ export type BeefyHash = Opaque<OpaqueHash, "BeefyHash">;
  * `X`: Refinement Context - state of the chain at the point
  * that the report's corresponding work-package was evaluated.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/138600138900
+ * https://graypaper.fluffylabs.dev/#/579bd12/13b80013bb00
  */
 export class RefineContext extends WithDebug {
   static Codec = codec.Class(RefineContext, {

--- a/packages/block/tickets.ts
+++ b/packages/block/tickets.ts
@@ -10,7 +10,7 @@ import { BANDERSNATCH_PROOF_BYTES, type BandersnatchProof } from "./crypto";
  * The index of a ticket entry per validator.
  *
  * Constrained by `N = 2`:
- * https://graypaper.fluffylabs.dev/#/c71229b/3d5f003d6100
+ * https://graypaper.fluffylabs.dev/#/579bd12/417200417400
  */
 export type TicketAttempt = Opaque<U8, "TicketAttempt[0|1|2]">;
 
@@ -66,10 +66,10 @@ export const MAX_NUMBER_OF_TICKETS = 16;
 /**
  * A sequence of proofs of valid tickets.
  *
- * https://graypaper.fluffylabs.dev/#/387103d/0e90020e9502
+ * https://graypaper.fluffylabs.dev/#/579bd12/0f13000f1800
  *
  * Constrained by `K = 16`:
- * https://graypaper.fluffylabs.dev/#/c71229b/3d59003d5b00
+ * https://graypaper.fluffylabs.dev/#/579bd12/416c00416e00
  */
 export type TicketsExtrinsic = KnownSizeArray<SignedTicket, `Size: 0..{MAX_NUMBER_OF_TICKETS}`>;
 

--- a/packages/block/work-item.ts
+++ b/packages/block/work-item.ts
@@ -27,7 +27,7 @@ export class ImportSpec extends WithDebug {
   constructor(
     /**
      * ??: TODO [ToDr] GP seems to mention a identity of a work-package:
-     * https://graypaper.fluffylabs.dev/#/c71229b/195500195500
+     * https://graypaper.fluffylabs.dev/#/579bd12/199300199300
      */
     public readonly treeRoot: OpaqueHash,
     /** Index of the prior exported segment. */
@@ -107,7 +107,7 @@ export function workItemExtrinsicsCodec(workItems: WorkItem[]) {
 /**
  * Work Item which is a part of some work package.
  *
- * https://graypaper.fluffylabs.dev/#/5b732de/199100199c00
+ * https://graypaper.fluffylabs.dev/#/579bd12/198b00199600
  */
 export class WorkItem extends WithDebug {
   static Codec = codec.Class(WorkItem, {

--- a/packages/block/work-package.ts
+++ b/packages/block/work-package.ts
@@ -30,7 +30,7 @@ export const MAX_NUMBER_OF_WORK_ITEMS = 4;
  *
  * `P = (j ∈ Y, h ∈ NS, u ∈ H, p ∈ Y, x ∈ X, w ∈ ⟦I⟧1∶I)
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/193300193500
+ * https://graypaper.fluffylabs.dev/#/579bd12/197000197200
  */
 export class WorkPackage extends WithDebug {
   static Codec = codec.Class(WorkPackage, {
@@ -71,7 +71,7 @@ export class WorkPackage extends WithDebug {
      * `w`: sequence of work items.
      *
      * Constrained by `I=4`:
-     * https://graypaper.fluffylabs.dev/#/c71229b/3d56003d5800
+     * https://graypaper.fluffylabs.dev/#/579bd12/416600416800
      */
     public readonly items: FixedSizeArray<WorkItem, WorkItemsCount>,
   ) {

--- a/packages/block/work-report.ts
+++ b/packages/block/work-report.ts
@@ -65,7 +65,7 @@ export class SegmentRootLookupItem {
 /**
  * A report of execution of some work package.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/133e00134500
+ * https://graypaper.fluffylabs.dev/#/579bd12/136f00137600
  */
 export class WorkReport extends WithDebug {
   static Codec = codec.Class(WorkReport, {
@@ -114,7 +114,7 @@ export class WorkReport extends WithDebug {
     public readonly authorizationOutput: BytesBlob,
     /** `l`: Segment-root lookup
      * In GP segment-root lookup is a dictionary but dictionary and var-len sequence are equal from codec perspective
-     * https://graypaper.fluffylabs.dev/#/911af30/13ab0013af00
+     * https://graypaper.fluffylabs.dev/#/579bd12/13ab0013ad00
      */
     public readonly segmentRootLookup: SegmentRootLookupItem[],
     /** `r`: The results of evaluation of each of the items in the work package. */

--- a/packages/block/work-result.ts
+++ b/packages/block/work-result.ts
@@ -67,7 +67,7 @@ export class WorkExecResult extends WithDebug {
 /**
  * A result of execution of some work package.
  *
- * https://graypaper.fluffylabs.dev/#/c71229b/131a01131f01
+ * https://graypaper.fluffylabs.dev/#/579bd12/133f01134401
  */
 export class WorkResult {
   static Codec = codec.Class(WorkResult, {
@@ -92,7 +92,7 @@ export class WorkResult {
      *
      * It has no immediate relevance, but is something provided to the accumulation logic of the service.
      *
-     * https://graypaper.fluffylabs.dev/#/c71229b/132201132201
+     * https://graypaper.fluffylabs.dev/#/579bd12/134701134701
      */
     public readonly payloadHash: OpaqueHash,
     /**

--- a/packages/codec/encoder.ts
+++ b/packages/codec/encoder.ts
@@ -219,7 +219,7 @@ export class Encoder {
   /**
    * Encode a single boolean discriminator using variable encoding.
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/335200335200
+   * https://graypaper.fluffylabs.dev/#/579bd12/375300375300
    */
   bool(bool: boolean) {
     this.varU32(tryAsU32(bool ? 1 : 0));
@@ -232,7 +232,7 @@ export class Encoder {
    * The encoding will always occupy N bytes in little-endian ordering.
    * Negative numbers are represented as a two-complement.
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/320402320402
+   * https://graypaper.fluffylabs.dev/#/579bd12/36fc0136fc01
    */
   private prepareIntegerN(num: number, bytesToEncode: 1 | 2 | 3 | 4) {
     const BITS = 8;
@@ -253,7 +253,7 @@ export class Encoder {
    *
    * The encoding can take variable amount of bytes depending on the actual value.
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/325a02325a02
+   * https://graypaper.fluffylabs.dev/#/579bd12/365202365202
    */
   varU32(num: U32) {
     check(num >= 0, "Only for natural numbers.");
@@ -266,7 +266,7 @@ export class Encoder {
    *
    * The encoding can take variable amount of bytes depending on the actual value.
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/325a02325a02
+   * https://graypaper.fluffylabs.dev/#/579bd12/365202365202
    */
   varU64(value: bigint) {
     const num = BigInt(value); // this should be a no-op, but fixes incorrect usage in JS
@@ -331,7 +331,7 @@ export class Encoder {
    * The data is placed in the destination, but with an
    * extra length-discriminator (see [`u32`]) encoded in a compact form.
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/332500332500
+   * https://graypaper.fluffylabs.dev/#/579bd12/372600372600
    */
   blob(blob: Uint8Array) {
     // first encode the length
@@ -349,7 +349,7 @@ export class Encoder {
    * The data is simply copied to the destination
    * without any discriminator (i.e. no length prefix).
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/331000331000
+   * https://graypaper.fluffylabs.dev/#/579bd12/371100371100
    *
    */
   bytes<N extends number>(bytes: Bytes<N>) {
@@ -363,7 +363,7 @@ export class Encoder {
    * Encode a bit vector with known length.
    *
    * The bits are packed into bytes and just placed as-is in the destination.
-   * https://graypaper.fluffylabs.dev/#/364735a/337f00337f00
+   * https://graypaper.fluffylabs.dev/#/579bd12/378000378000
    */
   bitVecFixLen(bitvec: BitVec) {
     const bytes = bitvec.raw;
@@ -374,7 +374,7 @@ export class Encoder {
    * Encode a bit vector with variable length.
    *
    * A bit-length discriminator (varU32) is placed before the packed bit content.
-   * https://graypaper.fluffylabs.dev/#/364735a/338100338100
+   * https://graypaper.fluffylabs.dev/#/579bd12/378200378200
    */
   bitVecVarLen(bitvec: BitVec) {
     const len = bitvec.bitLength;
@@ -394,7 +394,7 @@ export class Encoder {
    * Encode a potentially empty value.
    *
    * A 0 or 1 is placed before the element to indicate it's presence.
-   * https://graypaper.fluffylabs.dev/#/364735a/335e00335e00
+   * https://graypaper.fluffylabs.dev/#/579bd12/375f00375f00
    */
   optional<T>(encode: Encode<T>, element?: T | null) {
     const isSet = element !== null && element !== undefined;
@@ -408,7 +408,7 @@ export class Encoder {
   /**
    * Encode a fixed-length sequence of elements of some type.
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/331000331000
+   * https://graypaper.fluffylabs.dev/#/579bd12/371100371100
    */
   sequenceFixLen<T>(encode: Encode<T>, elements: T[]) {
     this.applySizeHint(encode, elements.length);
@@ -422,7 +422,7 @@ export class Encoder {
    *
    * A length discriminator is placed before the concatentation of encodings of all the elements.
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/334300334300
+   * https://graypaper.fluffylabs.dev/#/579bd12/374400374400
    */
   sequenceVarLen<T>(encode: Encode<T>, elements: T[]) {
     check(elements.length <= 2 ** 32, "Wow, that's a nice long sequence you've got here.");

--- a/packages/disputes/disputes-state.ts
+++ b/packages/disputes/disputes-state.ts
@@ -22,7 +22,7 @@ export function hashComparator<V extends WorkReportHash | Ed25519Key>(a: V, b: V
  * - wonkySet - all work-reports hashes which appear to be impossible to judge
  * - punishSet - set of Ed25519 keys representing validators which were found to have misjudged a work-report
  *
- * https://graypaper.fluffylabs.dev/#/911af30/122b00124700
+ * https://graypaper.fluffylabs.dev/#/579bd12/122b00124700
  */
 export class DisputesRecords {
   constructor(

--- a/packages/disputes/disputes.ts
+++ b/packages/disputes/disputes.ts
@@ -37,7 +37,7 @@ export class Disputes {
     verificationResult: VerificationOutput,
   ): Result<Ok, DisputesErrorCode> {
     // check if culprits are sorted by key
-    // https://graypaper.fluffylabs.dev/#/364735a/12ae0112af01
+    // https://graypaper.fluffylabs.dev/#/579bd12/12c50112c601
     if (!isUniqueSortedBy(disputes.culprits, "key")) {
       return Result.error(DisputesErrorCode.CulpritsNotSortedUnique);
     }
@@ -46,21 +46,21 @@ export class Disputes {
     for (let i = 0; i < culprintsLength; i++) {
       const { key, workReportHash } = disputes.culprits[i];
       // check if some offenders weren't reported earlier
-      // https://graypaper.fluffylabs.dev/#/364735a/123e01123e01
+      // https://graypaper.fluffylabs.dev/#/579bd12/125501125501
       const isInPunishSet = !!this.state.disputesRecords.punishSet.findExact(key);
       if (isInPunishSet) {
         return Result.error(DisputesErrorCode.OffenderAlreadyReported);
       }
 
       // verify if the culprit will be in new bad set
-      // https://graypaper.fluffylabs.dev/#/364735a/122f01122f01
+      // https://graypaper.fluffylabs.dev/#/579bd12/124601124601
       const isInNewBadSet = newItems.toAddToBadSet.findExact(workReportHash);
       if (!isInNewBadSet) {
         return Result.error(DisputesErrorCode.CulpritsVerdictNotBad);
       }
 
       // verify culprit signature
-      // https://graypaper.fluffylabs.dev/#/364735a/124501124501
+      // https://graypaper.fluffylabs.dev/#/579bd12/125c01125c01
       const result = verificationResult.culprits[i];
       if (!result || !result.isValid) {
         return Result.error(DisputesErrorCode.BadSignature);
@@ -76,7 +76,7 @@ export class Disputes {
     verificationResult: VerificationOutput,
   ): Result<Ok, DisputesErrorCode> {
     // check if faults are sorted by key
-    // https://graypaper.fluffylabs.dev/#/364735a/12ae0112af01
+    // https://graypaper.fluffylabs.dev/#/579bd12/12c50112c601
     if (!isUniqueSortedBy(disputes.faults, "key")) {
       return Result.error(DisputesErrorCode.FaultsNotSortedUnique);
     }
@@ -85,7 +85,7 @@ export class Disputes {
     for (let i = 0; i < faultsLength; i++) {
       const { key, workReportHash, wasConsideredValid } = disputes.faults[i];
       // check if some offenders weren't reported earlier
-      // https://graypaper.fluffylabs.dev/#/364735a/128b01128b01
+      // https://graypaper.fluffylabs.dev/#/579bd12/12a20112a201
       const isInPunishSet = !!this.state.disputesRecords.punishSet.findExact(key);
 
       if (isInPunishSet) {
@@ -96,7 +96,7 @@ export class Disputes {
       // it may be not correct as in GP there is "iff" what means it should be rather
       // if (!wasConsideredValid || isInNewGoodSet || !isInNewBadSet) return DisputesErrorCode.FaultVerdictWrong;
       // but it does not pass the tests
-      // https://graypaper.fluffylabs.dev/#/364735a/127301127f01
+      // https://graypaper.fluffylabs.dev/#/579bd12/128a01129601
       if (wasConsideredValid) {
         const isInNewGoodSet = newItems.toAddToGoodSet.findExact(workReportHash);
         const isInNewBadSet = newItems.toAddToBadSet.findExact(workReportHash);
@@ -107,7 +107,7 @@ export class Disputes {
       }
 
       // verify fault signature. Verification was done earlier, here we only check the result.
-      // https://graypaper.fluffylabs.dev/#/364735a/129201129201
+      // https://graypaper.fluffylabs.dev/#/579bd12/12a90112a901
       const result = verificationResult.faults[i];
       if (!result.isValid) {
         return Result.error(DisputesErrorCode.BadSignature);
@@ -122,13 +122,13 @@ export class Disputes {
     verificationResult: VerificationOutput,
   ): Result<Ok, DisputesErrorCode> {
     // check if verdicts are correctly sorted
-    // https://graypaper.fluffylabs.dev/#/364735a/12ad0112ad01
+    // https://graypaper.fluffylabs.dev/#/579bd12/12c40112c401
     if (!isUniqueSortedBy(disputes.verdicts, "workReportHash")) {
       return Result.error(DisputesErrorCode.VerdictsNotSortedUnique);
     }
 
     // check if judgement are correctly sorted
-    // https://graypaper.fluffylabs.dev/#/364735a/122102122202
+    // https://graypaper.fluffylabs.dev/#/579bd12/123702123802
     if (disputes.verdicts.some((verdict) => !isUniqueSortedByIndex(verdict.votes))) {
       return Result.error(DisputesErrorCode.JudgementsNotSortedUnique);
     }
@@ -136,7 +136,7 @@ export class Disputes {
     const currentEpoch = Math.floor(this.state.timeslot / this.context.epochLength);
     let voteSignatureIndex = 0;
     for (const { votesEpoch, votes } of disputes.verdicts) {
-      // https://graypaper.fluffylabs.dev/#/364735a/12a50012a600
+      // https://graypaper.fluffylabs.dev/#/579bd12/12bb0012bc00
       if (votesEpoch !== currentEpoch && votesEpoch + 1 !== currentEpoch) {
         return Result.error(DisputesErrorCode.BadJudgementAge);
       }
@@ -151,7 +151,7 @@ export class Disputes {
         }
 
         // verify vote signature. Verification was done earlier, here we only check the result.
-        // https://graypaper.fluffylabs.dev/#/364735a/12b70012b700
+        // https://graypaper.fluffylabs.dev/#/579bd12/12cd0012cd00
         const result = verificationResult.judgements[voteSignatureIndex];
         if (!result.isValid) {
           return Result.error(DisputesErrorCode.BadSignature);
@@ -166,7 +166,7 @@ export class Disputes {
   private verifyIfAlreadyJudged(disputes: DisputesExtrinsic): Result<Ok, DisputesErrorCode> {
     for (const verdict of disputes.verdicts) {
       // current verdicts should not be reported earlier
-      // https://graypaper.fluffylabs.dev/#/364735a/120b02120b02
+      // https://graypaper.fluffylabs.dev/#/579bd12/122202122202
       const isInGoodSet = this.state.disputesRecords.goodSet.findExact(verdict.workReportHash);
       const isInBadSet = this.state.disputesRecords.badSet.findExact(verdict.workReportHash);
       const isInWonkySet = this.state.disputesRecords.wonkySet.findExact(verdict.workReportHash);
@@ -181,7 +181,7 @@ export class Disputes {
 
   private calculateVotesForWorkReports(disputes: DisputesExtrinsic) {
     // calculate total votes for each work report
-    // https://graypaper.fluffylabs.dev/#/364735a/12760212cd02
+    // https://graypaper.fluffylabs.dev/#/579bd12/128c0212e302
     const v = new HashDictionary<WorkReportHash, number>();
 
     for (const verdict of disputes.verdicts) {
@@ -206,19 +206,19 @@ export class Disputes {
     disputes: DisputesExtrinsic,
   ): Result<Ok, DisputesErrorCode> {
     // verify if the vote split is correct and if number of faults/culprints is correct
-    // https://graypaper.fluffylabs.dev/#/364735a/12e50212fa02
+    // https://graypaper.fluffylabs.dev/#/579bd12/12fb02121003
 
     for (const [r, sum] of v) {
       if (sum === this.context.validatorsSuperMajority) {
         // there has to be at least 1 fault with the same work report hash
-        // https://graypaper.fluffylabs.dev/#/364735a/12db0212e602
+        // https://graypaper.fluffylabs.dev/#/579bd12/12f10212fc02
         const f = disputes.faults.find((x) => x.workReportHash.isEqualTo(r));
         if (!f) {
           return Result.error(DisputesErrorCode.NotEnoughFaults);
         }
       } else if (sum === 0) {
         // there has to be at least 2 culprits with the same work report hash
-        // https://graypaper.fluffylabs.dev/#/364735a/12f60212fa02
+        // https://graypaper.fluffylabs.dev/#/579bd12/120c03121003
         const c1 = disputes.culprits.find((x) => x.workReportHash.isEqualTo(r));
         const c2 = disputes.culprits.findLast((x) => x.workReportHash.isEqualTo(r));
         if (c1 === c2) {
@@ -226,7 +226,7 @@ export class Disputes {
         }
       } else if (sum !== this.context.thirdOfValidators) {
         // positive votes count is not correct
-        // https://graypaper.fluffylabs.dev/#/364735a/123a02126b02
+        // https://graypaper.fluffylabs.dev/#/579bd12/125002128102
         return Result.error(DisputesErrorCode.BadVoteSplit);
       }
     }
@@ -241,7 +241,7 @@ export class Disputes {
 
     // prepare new disputes records items but do not update the state yet
     // the state will be updated after verification
-    // https://graypaper.fluffylabs.dev/#/364735a/123403128f03
+    // https://graypaper.fluffylabs.dev/#/579bd12/124a0312a503
     for (const [r, sum] of v) {
       if (sum >= this.context.validatorsSuperMajority) {
         toAddToGoodSet.push(r);
@@ -260,7 +260,7 @@ export class Disputes {
   }
 
   private clearCoreAssignment(v: VotesForWorkReports) {
-    // https://graypaper.fluffylabs.dev/#/364735a/120403122903
+    // https://graypaper.fluffylabs.dev/#/579bd12/121a03123f03
     for (let c = 0; c < this.state.availabilityAssignment.length; c++) {
       const assignment = this.state.availabilityAssignment[c];
       if (assignment) {
@@ -274,7 +274,7 @@ export class Disputes {
   }
 
   private getOffenders(disputes: DisputesExtrinsic) {
-    // https://graypaper.fluffylabs.dev/#/364735a/12a50312a503
+    // https://graypaper.fluffylabs.dev/#/579bd12/12bb0312bb03
     const offendersMarks: Ed25519Key[] = [];
 
     for (const { key } of disputes.culprits) {
@@ -289,7 +289,7 @@ export class Disputes {
   }
 
   private updateDisputesRecords(newItems: NewDisputesRecordsItems, offenders: Ed25519Key[]) {
-    // https://graypaper.fluffylabs.dev/#/364735a/12530312a603
+    // https://graypaper.fluffylabs.dev/#/579bd12/12690312bc03
     this.state.disputesRecords.goodSet = SortedSet.fromTwoSortedCollections(
       this.state.disputesRecords.goodSet,
       newItems.toAddToGoodSet,
@@ -326,17 +326,17 @@ export class Disputes {
 
         const key = validator.ed25519;
         // verify vote signature
-        // https://graypaper.fluffylabs.dev/#/364735a/12b70012b700
+        // https://graypaper.fluffylabs.dev/#/579bd12/12cd0012cd00
         signaturesToVerification.judgements.push(prepareJudgementSignature(j, workReportHash, key));
       }
     }
 
     // verify culprit signature
-    // https://graypaper.fluffylabs.dev/#/364735a/124501124501
+    // https://graypaper.fluffylabs.dev/#/579bd12/125c01125c01
     signaturesToVerification.culprits = disputes.culprits.map(prepareCulpritSignature);
 
     // verify fault signature
-    // https://graypaper.fluffylabs.dev/#/364735a/129201129201
+    // https://graypaper.fluffylabs.dev/#/579bd12/12a90112a901
     signaturesToVerification.faults = disputes.faults.map(prepareFaultSignature);
 
     return Result.ok(signaturesToVerification);
@@ -366,7 +366,7 @@ export class Disputes {
       return Result.error(inputError.error);
     }
 
-    // GP: https://graypaper.fluffylabs.dev/#/364735a/12b00312cd03
+    // GP: https://graypaper.fluffylabs.dev/#/579bd12/131300133000
     const offendersMarks = this.getOffenders(disputes);
     this.updateDisputesRecords(newItems, offendersMarks);
     this.clearCoreAssignment(v);

--- a/packages/erasure-coding/erasure-encoding.ts
+++ b/packages/erasure-coding/erasure-encoding.ts
@@ -5,7 +5,7 @@ const SHARD_ALIGNMENT = 64; // Shard size must be multiple of 64 bytes. (reed-so
 
 /**
  * The following values are the consequences of the coding rate 342:1023
- * https://graypaper.fluffylabs.dev/#/364735a/382100382100
+ * https://graypaper.fluffylabs.dev/#/579bd12/3c55003c5500
  */
 const N_SHARDS = 342;
 const RESULT_SHARDS = 1023;
@@ -20,7 +20,7 @@ const SECOND_POINT_INDEX = 32;
 
 /**
  * The shards are 2 bytes length because the encoding function is defined in GF(16)
- * https://graypaper.fluffylabs.dev/#/364735a/37d10237d102
+ * https://graypaper.fluffylabs.dev/#/579bd12/3c17003c1700
  */
 const SHARD_LENGTH = 2;
 

--- a/packages/hash/hash.ts
+++ b/packages/hash/hash.ts
@@ -4,7 +4,7 @@ import { WithDebug } from "@typeberry/utils";
 /**
  * Size of the output of the hash functions.
  *
- * https://graypaper.fluffylabs.dev/#/387103d/071401071f01
+ * https://graypaper.fluffylabs.dev/#/579bd12/073101073c01
  *
  */
 export const HASH_SIZE = 32;

--- a/packages/mmr/index.ts
+++ b/packages/mmr/index.ts
@@ -24,7 +24,7 @@ export interface MmrHasher<H extends OpaqueHash> {
 /**
  * Merkle Mountain Range.
  *
- * https://graypaper.fluffylabs.dev/#/6e1c0cd/399c00399c00
+ * https://graypaper.fluffylabs.dev/#/579bd12/3aa0023aa002
  */
 export class MerkleMountainRange<H extends OpaqueHash> {
   /** Construct an empty MMR. */

--- a/packages/pvm/host-calls-jam/accumulate/assign.ts
+++ b/packages/pvm/host-calls-jam/accumulate/assign.ts
@@ -22,7 +22,7 @@ const IN_OUT_REG = 7;
 /**
  * Assign new fixed-length authorization queue to some core.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2ebf002ebf00
+ * https://graypaper.fluffylabs.dev/#/579bd12/311702311702
  */
 export class Assign implements HostCallHandler {
   index = tryAsHostCallIndex(6);

--- a/packages/pvm/host-calls-jam/accumulate/checkpoint.ts
+++ b/packages/pvm/host-calls-jam/accumulate/checkpoint.ts
@@ -8,7 +8,7 @@ import type { AccumulationPartialState } from "./partial-state";
 /**
  * Checkpoint the partial state.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2ecd012ecd01
+ * https://graypaper.fluffylabs.dev/#/579bd12/312503312503
  */
 export class Checkpoint implements HostCallHandler {
   index = tryAsHostCallIndex(8);

--- a/packages/pvm/host-calls-jam/accumulate/designate.ts
+++ b/packages/pvm/host-calls-jam/accumulate/designate.ts
@@ -16,7 +16,7 @@ export const VALIDATOR_DATA_BYTES = tryAsExactBytes(ValidatorData.Codec.sizeHint
 /**
  * Designate a new set of validator keys.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2e4e012e4e01
+ * https://graypaper.fluffylabs.dev/#/579bd12/31a60231a602
  */
 export class Designate implements HostCallHandler {
   index = tryAsHostCallIndex(7);

--- a/packages/pvm/host-calls-jam/accumulate/empower.ts
+++ b/packages/pvm/host-calls-jam/accumulate/empower.ts
@@ -27,7 +27,7 @@ const serviceIdAndGasCodec = codec.object({
 /**
  * Modify privileged services and services that auto-accumulate every block.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2e3a002e3a00
+ * https://graypaper.fluffylabs.dev/#/579bd12/317d01317d01
  */
 export class Empower implements HostCallHandler {
   index = tryAsHostCallIndex(5);

--- a/packages/pvm/host-calls-jam/accumulate/forget.ts
+++ b/packages/pvm/host-calls-jam/accumulate/forget.ts
@@ -19,7 +19,7 @@ const IN_OUT_REG = 7;
 /**
  * Mark a preimage hash as unavailable.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/303a00303a00
+ * https://graypaper.fluffylabs.dev/#/579bd12/33ee0133ee01
  */
 export class Forget implements HostCallHandler {
   index = tryAsHostCallIndex(14);

--- a/packages/pvm/host-calls-jam/accumulate/new.ts
+++ b/packages/pvm/host-calls-jam/accumulate/new.ts
@@ -15,7 +15,7 @@ const IN_OUT_REG = 7;
 /**
  * Create a new service account.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2e11022e1102
+ * https://graypaper.fluffylabs.dev/#/579bd12/323f00323f00
  */
 export class New implements HostCallHandler {
   index = tryAsHostCallIndex(9);

--- a/packages/pvm/host-calls-jam/accumulate/partial-state.ts
+++ b/packages/pvm/host-calls-jam/accumulate/partial-state.ts
@@ -61,21 +61,21 @@ export enum QuitError {
  * - `q`: queue of work reports
  * - `x`: priviliges state
  *
- * https://graypaper.fluffylabs.dev/#/439ca37/161402161402
+ * https://graypaper.fluffylabs.dev/#/579bd12/163602163602
  */
 export interface AccumulationPartialState {
   /**
    * Request (solicit) a preimage to be (re-)available.
    *
    * States:
-   * https://graypaper.fluffylabs.dev/#/364735a/113000113000
+   * https://graypaper.fluffylabs.dev/#/579bd12/116f00116f00
    */
   requestPreimage(hash: Blake2bHash, length: U32): Result<null, RequestPreimageError>;
 
   /**
    * Mark a preimage hash as unavailable (forget it).
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/30a20030a200
+   * https://graypaper.fluffylabs.dev/#/579bd12/335602335602
    */
   forgetPreimage(hash: Blake2bHash, length: U32): Result<null, null>;
 
@@ -111,7 +111,7 @@ export interface AccumulationPartialState {
    *
    * Note the assigned id might be different than requested
    * in case of a conflict.
-   * https://graypaper.fluffylabs.dev/#/364735a/2b5c012b5c01
+   * https://graypaper.fluffylabs.dev/#/579bd12/2e14012e1401
    *
    * An error can be returned in case the account does not
    * have the required balance.
@@ -135,7 +135,7 @@ export interface AccumulationPartialState {
    *
    * I.e. assign the "regular dimension" of the context to
    * the "exceptional dimension".
-   * https://graypaper.fluffylabs.dev/#/364735a/2a96022a9602
+   * https://graypaper.fluffylabs.dev/#/579bd12/2df4012df401
    */
   checkpoint(): void;
 

--- a/packages/pvm/host-calls-jam/accumulate/quit.ts
+++ b/packages/pvm/host-calls-jam/accumulate/quit.ts
@@ -14,7 +14,9 @@ const IN_OUT_REG = 7;
 /**
  * Remove the current service id and transfer or burn the remaining account balance to some other account.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2f36012f3601
+ * TODO [ToDr] Rename to eject
+ *
+ * https://graypaper.fluffylabs.dev/#/579bd12/32c10232c102
  */
 export class Quit implements HostCallHandler {
   index = tryAsHostCallIndex(12);

--- a/packages/pvm/host-calls-jam/accumulate/solicit.ts
+++ b/packages/pvm/host-calls-jam/accumulate/solicit.ts
@@ -20,7 +20,7 @@ const IN_OUT_REG = 7;
 /**
  * Request a preimage to be available.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2f20022f2002
+ * https://graypaper.fluffylabs.dev/#/579bd12/33fd0033fd00
  */
 export class Solicit implements HostCallHandler {
   index = tryAsHostCallIndex(13);

--- a/packages/pvm/host-calls-jam/accumulate/transfer.ts
+++ b/packages/pvm/host-calls-jam/accumulate/transfer.ts
@@ -22,14 +22,14 @@ const AMOUNT_HIG_REG = 9;
 /**
  * Transfer balance from one service account to another.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2f3a002f3a00
+ * https://graypaper.fluffylabs.dev/#/579bd12/32c20132c201
  */
 export class Transfer implements HostCallHandler {
   index = tryAsHostCallIndex(11);
   /**
    * `g = 10 + ω8 + 2**32 * ω9`
    *
-   * https://graypaper.fluffylabs.dev/#/364735a/2f3c002f3f00
+   * https://graypaper.fluffylabs.dev/#/579bd12/32c30132c601
    */
   gasCost = (regs: Registers): Gas => {
     const smallGas = 10 + regs.getU32(AMOUNT_LOW_REG);

--- a/packages/pvm/host-calls-jam/accumulate/upgrade.ts
+++ b/packages/pvm/host-calls-jam/accumulate/upgrade.ts
@@ -19,7 +19,7 @@ const IN_OUT_REG = 7;
 /**
  * Upgrade the code of the service.
  *
- * https://graypaper.fluffylabs.dev/#/364735a/2e01032e0103
+ * https://graypaper.fluffylabs.dev/#/579bd12/324401324401
  */
 export class Upgrade implements HostCallHandler {
   index = tryAsHostCallIndex(10);

--- a/packages/pvm/host-calls-jam/gas.ts
+++ b/packages/pvm/host-calls-jam/gas.ts
@@ -8,7 +8,7 @@ import { CURRENT_SERVICE_ID } from "./utils";
  *
  * NOTE it should be the gas left is AFTER this function is invoked.
  *
- * https://graypaper.fluffylabs.dev/#/439ca37/2c6c012c6c01
+ * https://graypaper.fluffylabs.dev/#/579bd12/2f87012f8701
  */
 export class Gas implements HostCallHandler {
   index = tryAsHostCallIndex(0);

--- a/packages/pvm/host-calls-jam/info.ts
+++ b/packages/pvm/host-calls-jam/info.ts
@@ -22,7 +22,7 @@ import { CURRENT_SERVICE_ID, getServiceId } from "./utils";
  * In case some of the things are computed (and the computation may be heavy)
  * this should be split.
  *
- * https://graypaper.fluffylabs.dev/#/439ca37/10e70010e700
+ * https://graypaper.fluffylabs.dev/#/579bd12/105a01105a01
  */
 export class AccountInfo extends WithDebug {
   static Codec = codec.Class(AccountInfo, {
@@ -55,11 +55,11 @@ export class AccountInfo extends WithDebug {
 
   /** `a_t = BS + BI * a_i + BL * a_l` */
   static calculateThresholdBalance(items: U32, bytes: U64): U64 {
-    /** https://graypaper.fluffylabs.dev/#/439ca37/3d30003d3000 */
+    /** https://graypaper.fluffylabs.dev/#/579bd12/413e00413e00 */
     const B_S = 100n;
-    /** https://graypaper.fluffylabs.dev/#/439ca37/3d28003d2800 */
+    /** https://graypaper.fluffylabs.dev/#/579bd12/413600413600 */
     const B_I = 10n;
-    /** https://graypaper.fluffylabs.dev/#/439ca37/3d2c003d2d00 */
+    /** https://graypaper.fluffylabs.dev/#/579bd12/413a00413b00 */
     const B_L = 1n;
 
     // TODO [ToDr] Overflows?
@@ -106,7 +106,7 @@ const IN_OUT_REG = 7;
  * i = number of items in the storage
  * l = total number of octets stored.
  *
- * https://graypaper.fluffylabs.dev/#/439ca37/2d45022d4502
+ * https://graypaper.fluffylabs.dev/#/579bd12/313b00313b00
  */
 export class Info implements HostCallHandler {
   index = tryAsHostCallIndex(4);

--- a/packages/pvm/host-calls-jam/lookup.ts
+++ b/packages/pvm/host-calls-jam/lookup.ts
@@ -24,7 +24,7 @@ const IN_OUT_REG = 7;
 /**
  * Lookup a preimage.
  *
- * https://graypaper.fluffylabs.dev/#/439ca37/2ca7012ca701
+ * https://graypaper.fluffylabs.dev/#/579bd12/303b00303b00
  */
 export class Lookup implements HostCallHandler {
   index = tryAsHostCallIndex(1);

--- a/packages/pvm/host-calls-jam/read.ts
+++ b/packages/pvm/host-calls-jam/read.ts
@@ -28,7 +28,7 @@ const IN_OUT_REG = 7;
 /**
  * Read account storage.
  *
- * https://graypaper.fluffylabs.dev/#/439ca37/2d3a002d3a00
+ * https://graypaper.fluffylabs.dev/#/579bd12/304101304101
  */
 export class Read implements HostCallHandler {
   index = tryAsHostCallIndex(2);

--- a/packages/pvm/host-calls-jam/refine/export.ts
+++ b/packages/pvm/host-calls-jam/refine/export.ts
@@ -17,7 +17,7 @@ const IN_OUT_REG = 7;
 /**
  * Export a segment to be imported by some future `refine` invokation.
  *
- * https://graypaper.fluffylabs.dev/#/911af30/333b00333b00
+ * https://graypaper.fluffylabs.dev/#/579bd12/340b02340b02
  */
 export class Export implements HostCallHandler {
   index = tryAsHostCallIndex(16);

--- a/packages/pvm/host-calls-jam/refine/expunge.ts
+++ b/packages/pvm/host-calls-jam/refine/expunge.ts
@@ -9,7 +9,7 @@ const IN_OUT_REG = 7;
 /**
  * Forget a previously started nested machine.
  *
- * https://graypaper.fluffylabs.dev/#/5b732de/343102343102
+ * https://graypaper.fluffylabs.dev/#/579bd12/367c01367c01
  */
 export class Expunge implements HostCallHandler {
   index = tryAsHostCallIndex(24);

--- a/packages/pvm/host-calls-jam/refine/historical-lookup.ts
+++ b/packages/pvm/host-calls-jam/refine/historical-lookup.ts
@@ -15,7 +15,7 @@ const IN_OUT_REG = 7;
 /**
  * Lookup a historical preimage.
  *
- * https://graypaper.fluffylabs.dev/#/911af30/329501329501
+ * https://graypaper.fluffylabs.dev/#/579bd12/346800346800
  */
 export class HistoricalLookup implements HostCallHandler {
   index = tryAsHostCallIndex(15);

--- a/packages/pvm/host-calls-jam/refine/import.ts
+++ b/packages/pvm/host-calls-jam/refine/import.ts
@@ -18,7 +18,7 @@ const IN_OUT_REG = 7;
 /**
  * Import a segment that was exported by some previous `refine` of the current service.
  *
- * https://graypaper.fluffylabs.dev/#/911af30/328202328202
+ * https://graypaper.fluffylabs.dev/#/579bd12/345501345501
  */
 export class Import implements HostCallHandler {
   index = tryAsHostCallIndex(16);

--- a/packages/pvm/host-calls-jam/refine/machine.ts
+++ b/packages/pvm/host-calls-jam/refine/machine.ts
@@ -17,7 +17,7 @@ const IN_OUT_REG = 7;
 /**
  * Start a nested PVM instance with given program code and entrypoint (program counter).
  *
- * https://graypaper.fluffylabs.dev/#/911af30/33cb0033cb00
+ * https://graypaper.fluffylabs.dev/#/579bd12/349902349902
  */
 export class Machine implements HostCallHandler {
   index = tryAsHostCallIndex(18);

--- a/packages/pvm/host-calls-jam/refine/peek.ts
+++ b/packages/pvm/host-calls-jam/refine/peek.ts
@@ -17,7 +17,7 @@ const IN_OUT_REG = 7;
 /**
  * Peek a piece memory of a running nested machine.
  *
- * https://graypaper.fluffylabs.dev/#/911af30/338801338801
+ * https://graypaper.fluffylabs.dev/#/579bd12/353b00353b00
  */
 export class Peek implements HostCallHandler {
   index = tryAsHostCallIndex(19);

--- a/packages/pvm/host-calls-jam/refine/poke.ts
+++ b/packages/pvm/host-calls-jam/refine/poke.ts
@@ -17,7 +17,7 @@ const IN_OUT_REG = 7;
 /**
  * Copy a piece of local memory into nested PVM instance.
  *
- * https://graypaper.fluffylabs.dev/#/911af30/332302332302
+ * https://graypaper.fluffylabs.dev/#/579bd12/35d60035d600
  */
 export class Poke implements HostCallHandler {
   index = tryAsHostCallIndex(20);

--- a/packages/pvm/host-calls-jam/refine/void.ts
+++ b/packages/pvm/host-calls-jam/refine/void.ts
@@ -12,7 +12,7 @@ const IN_OUT_REG = 7;
 /**
  * Mark some pages as unavailable and zero their content.
  *
- * https://graypaper.fluffylabs.dev/#/5b732de/343b00343b00
+ * https://graypaper.fluffylabs.dev/#/579bd12/352102352102
  */
 export class Void implements HostCallHandler {
   index = tryAsHostCallIndex(22);

--- a/packages/pvm/host-calls-jam/refine/zero.ts
+++ b/packages/pvm/host-calls-jam/refine/zero.ts
@@ -8,15 +8,15 @@ import { type RefineExternalities, tryAsMachineId } from "./refine-externalities
 
 const IN_OUT_REG = 7;
 
-/** https://graypaper.fluffylabs.dev/#/911af30/333f03333f03 */
+/** https://graypaper.fluffylabs.dev/#/579bd12/35f20135f201 */
 const RESERVED_NUMBER_OF_PAGES = 16;
-/** https://graypaper.fluffylabs.dev/#/911af30/333f03333f03 */
+/** https://graypaper.fluffylabs.dev/#/579bd12/35f20135f201 */
 export const MAX_NUMBER_OF_PAGES = MEMORY_SIZE / 2 ** 12;
 
 /**
  * Initialize some pages of memory for writing for a nested PVM.
  *
- * https://graypaper.fluffylabs.dev/#/911af30/33bf0233bf02
+ * https://graypaper.fluffylabs.dev/#/579bd12/357201357201
  */
 export class Zero implements HostCallHandler {
   index = tryAsHostCallIndex(21);

--- a/packages/pvm/host-calls-jam/results.ts
+++ b/packages/pvm/host-calls-jam/results.ts
@@ -1,7 +1,7 @@
 /**
  * Host call result constants.
  *
- * https://graypaper.fluffylabs.dev/#/439ca37/298002298002
+ * https://graypaper.fluffylabs.dev/#/579bd12/2c77022c7702
  */
 export enum HostCallResult {
   /** The return value indicating an item does not exist. */

--- a/packages/pvm/host-calls-jam/write.ts
+++ b/packages/pvm/host-calls-jam/write.ts
@@ -29,7 +29,7 @@ export interface Accounts {
    * It means that the threshold balance `a_t` is greater than current account balance `a_b`.
    * TODO [ToDr] Can be computed from `AccountInfo` - might need to be merged later.
    *
-   * https://graypaper.fluffylabs.dev/#/439ca37/2d2a022d2e02
+   * https://graypaper.fluffylabs.dev/#/579bd12/303103303503
    */
   isStorageFull(serviceId: ServiceId): Promise<boolean>;
 
@@ -46,7 +46,7 @@ const IN_OUT_REG = 7;
 /**
  * Write account storage.
  *
- * https://graypaper.fluffylabs.dev/#/439ca37/2d4e012d4e01
+ * https://graypaper.fluffylabs.dev/#/579bd12/305502305502
  */
 export class Write implements HostCallHandler {
   index = tryAsHostCallIndex(3);
@@ -59,7 +59,7 @@ export class Write implements HostCallHandler {
     // Storage is full (i.e. `a_t > a_b` - threshold balance is greater than current balance).
     // NOTE that we first need to know if the storage is full, since the result
     // does not depend on the success of reading the key or value:
-    // https://graypaper.fluffylabs.dev/#/439ca37/2d2a022d2a02
+    // https://graypaper.fluffylabs.dev/#/579bd12/303103303103
     const isStorageFull = await this.account.isStorageFull(this.currentServiceId);
     if (isStorageFull) {
       regs.setU32(IN_OUT_REG, HostCallResult.FULL);

--- a/packages/pvm/interpreter/interpreter.ts
+++ b/packages/pvm/interpreter/interpreter.ts
@@ -167,7 +167,7 @@ export class Interpreter {
      * - change status to panic and quit program immediately,
      * - treat the invalid instruction as a regular trap.
      * The difference is that in the second case we don't need any additional condition and gas will be subtracted automagically so this option is implemented
-     * Reference: https://graypaper.fluffylabs.dev/#/364735a/232f02233002
+     * Reference: https://graypaper.fluffylabs.dev/#/579bd12/251100251200
      */
     const currentInstruction = this.code[this.pc] ?? Instruction.TRAP;
     const isValidInstruction = !!Instruction[currentInstruction];

--- a/packages/pvm/interpreter/memory/pages/page-utils.ts
+++ b/packages/pvm/interpreter/memory/pages/page-utils.ts
@@ -18,10 +18,10 @@ export const tryAsPageNumber = (index: number): PageNumber =>
  *
  * GP references:
  * 1. The modulo subscription operator is used in all load/store instructions, for example:
- * https://graypaper.fluffylabs.dev/#/364735a/244501244501
+ * https://graypaper.fluffylabs.dev/#/579bd12/25af0125af01
  *
  * 2. Here is the definition of the modulo subscription operator:
- * https://graypaper.fluffylabs.dev/#/364735a/073900073900
+ * https://graypaper.fluffylabs.dev/#/579bd12/073a00073a00
  */
 export function getNextPageNumber(pageNumber: PageNumber): PageNumber {
   const newPageNumber = pageNumber === LAST_PAGE_NUMBER ? 0 : pageNumber + 1;

--- a/packages/pvm/interpreter/ops/dynamic-jump-ops.ts
+++ b/packages/pvm/interpreter/ops/dynamic-jump-ops.ts
@@ -7,7 +7,7 @@ import { Result } from "../result";
 import { addWithOverflowU32 } from "./math-utils";
 
 const EXIT = 0xff_ff_00_00;
-/** `Z_A`: https://graypaper.fluffylabs.dev/#/911af30/24ed0124ee01 */
+/** `Z_A`: https://graypaper.fluffylabs.dev/#/579bd12/248402248402 */
 const JUMP_ALIGMENT_FACTOR = 2;
 
 export class DynamicJumpOps {

--- a/packages/pvm/spi-decoder/decode-standard-program.ts
+++ b/packages/pvm/spi-decoder/decode-standard-program.ts
@@ -15,7 +15,7 @@ const NO_OF_REGISTERS = 13;
  * s - stack size
  * c - program code
  *
- * GP reference: https://graypaper.fluffylabs.dev/#/364735a/284a03284a03
+ * https://graypaper.fluffylabs.dev/#/579bd12/2b92022b9202
  */
 type InputLength = Opaque<number, "Number that is lower than 2 ** 24 (Z_I from GP)">;
 
@@ -108,7 +108,7 @@ function getMemorySegment(start: number, end: number, data: Uint8Array | null = 
 function getRegisters(argsLength: number) {
   const regs = new BigUint64Array(NO_OF_REGISTERS);
 
-  // GP reference: https://graypaper.fluffylabs.dev/#/293bf5a/29860129bb01
+  // GP reference: https://graypaper.fluffylabs.dev/#/579bd12/2c7c012cb101
   regs[0] = BigInt(LAST_PAGE);
   regs[1] = BigInt(STACK_SEGMENT);
   regs[7] = BigInt(ARGS_SEGMENT);

--- a/packages/pvm/spi-decoder/memory-conts.ts
+++ b/packages/pvm/spi-decoder/memory-conts.ts
@@ -1,4 +1,4 @@
-// GP reference: https://graypaper.fluffylabs.dev/#/364735a/286203286203
+// GP reference: https://graypaper.fluffylabs.dev/#/579bd12/2ba8022ba802
 
 export const PAGE_SIZE = 2 ** 12; // Z_P from GP
 export const SEGMENT_SIZE = 2 ** 16; // Z_Q from GP

--- a/packages/pvm/spi-decoder/memory-utils.ts
+++ b/packages/pvm/spi-decoder/memory-utils.ts
@@ -1,6 +1,6 @@
 import { PAGE_SIZE, SEGMENT_SIZE } from "./memory-conts";
 
-// GP reference: https://graypaper.fluffylabs.dev/#/364735a/288c03288c03
+// GP reference: https://graypaper.fluffylabs.dev/#/579bd12/2bd2022bd202
 
 export function alignToSegmentSize(size: number) {
   // Q(x) from GP

--- a/packages/shuffling/shuffling.ts
+++ b/packages/shuffling/shuffling.ts
@@ -5,7 +5,7 @@ import { check } from "@typeberry/utils";
 /**
  * Deterministic variant of the Fisher–Yates shuffle function
  *
- * https://graypaper.fluffylabs.dev/#/5b732de/393402393402
+ * https://graypaper.fluffylabs.dev/#/579bd12/3b9a013b9a01
  */
 export function fisherYatesShuffle<T>(arr: T[], entropy: Bytes<32>): T[] {
   check(entropy.length === 32, `Expected entropy of length 32, got ${entropy.length}`);

--- a/packages/statistics/statistics-state.ts
+++ b/packages/statistics/statistics-state.ts
@@ -2,7 +2,7 @@ import type { TimeSlot, ValidatorData } from "@typeberry/block";
 import { type U32, tryAsU32 } from "@typeberry/numbers";
 
 /**
- * https://graypaper.fluffylabs.dev/#/6e1c0cd/187a01187a01
+ * https://graypaper.fluffylabs.dev/#/579bd12/183701183701
  */
 export class ActivityRecord {
   constructor(
@@ -50,7 +50,7 @@ export class StatisticsState {
     /**
      * `pi`: Previous and current statistics of each validator.
      *
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/185d01185f01
+     * https://graypaper.fluffylabs.dev/#/579bd12/181a01181c01
      */
     public statisticsPerValidator: {
       current: ActivityRecord[];
@@ -60,14 +60,14 @@ export class StatisticsState {
     /**
      * The current time slot.
      *
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/18a70118a701
+     * https://graypaper.fluffylabs.dev/#/579bd12/186401186401
      */
     public tau: TimeSlot,
 
     /**
      * Posterior active validators
      *
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/18cf0218d002
+     * https://graypaper.fluffylabs.dev/#/579bd12/188c02188d02
      */
     public kappaPrime: ValidatorData[],
   ) {}

--- a/packages/statistics/statistics.ts
+++ b/packages/statistics/statistics.ts
@@ -11,7 +11,7 @@ export class Statistics {
   ) {}
 
   private getValidatorsStatistics(slot: TimeSlot) {
-    /** https://graypaper.fluffylabs.dev/#/6e1c0cd/18fb0118fb01 */
+    /** https://graypaper.fluffylabs.dev/#/579bd12/18b80118b801 */
     const currentEpoch = Math.floor(this.state.tau / this.chainSpec.epochLength);
     const nextEpoch = Math.floor(slot / this.chainSpec.epochLength);
 
@@ -40,23 +40,23 @@ export class Statistics {
     check(current[authorIndex] !== undefined, "authorIndex is out of bounds");
 
     /**
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/184b02184b02
+     * https://graypaper.fluffylabs.dev/#/579bd12/180802180802
      */
 
     current[authorIndex].blocks = tryAsU32(current[authorIndex].blocks + 1);
 
     /**
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/185e02185e02
+     * https://graypaper.fluffylabs.dev/#/579bd12/181b02181b02
      */
     current[authorIndex].tickets = tryAsU32(current[authorIndex].tickets + extrinsic.tickets.length);
 
     /**
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/188202189a02
+     * https://graypaper.fluffylabs.dev/#/579bd12/183f02185702
      */
     current[authorIndex].preImages = tryAsU32(current[authorIndex].preImages + extrinsic.preimages.length);
 
     /**
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/18a60218a602
+     * https://graypaper.fluffylabs.dev/#/579bd12/186302186302
      *
      * This value is well bounded by number of blocks in the epoch and maximal amount of preimage data in the extrinsics per one validator. So it can't reach 2GB.
      */
@@ -64,7 +64,7 @@ export class Statistics {
     current[authorIndex].preImagesSize = tryAsU32(current[authorIndex].preImagesSize + preImagesSize);
 
     /**
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/18cc0218d002
+     * https://graypaper.fluffylabs.dev/#/579bd12/188902188d02
      *
      * Please note I don't use Kappa' here. If I understand correctly we don't need it.
      * Kappa' is not needed because we can use validator indexes directly from guarantees extrinsic.
@@ -78,7 +78,7 @@ export class Statistics {
     }
 
     /**
-     * https://graypaper.fluffylabs.dev/#/6e1c0cd/18dc0218dc02
+     * https://graypaper.fluffylabs.dev/#/579bd12/189902189902
      */
     for (const assurance of extrinsic.assurances) {
       current[assurance.validatorIndex].assurances = tryAsU32(current[assurance.validatorIndex].assurances + 1);

--- a/packages/transition/hasher.ts
+++ b/packages/transition/hasher.ts
@@ -16,6 +16,7 @@ export class TransitionHasher {
   }
 
   extrinsic(extrinsic: Extrinsic): WithHashAndBytes<ExtrinsicHash, Extrinsic> {
+    // TODO [ToDr] This is incorrect, since extrinc hash should be a merkle root.
     return this.encode(Extrinsic.Codec, extrinsic);
   }
 

--- a/packages/transition/recent-history.ts
+++ b/packages/transition/recent-history.ts
@@ -7,7 +7,7 @@ import { MerkleMountainRange, type MmrHasher, type MmrPeaks } from "@typeberry/m
 /**
  * `H = 8`: The size of recent history, in blocks.
  *
- * https://graypaper.fluffylabs.dev/#/6e1c0cd/3f5d003f5f00
+ * https://graypaper.fluffylabs.dev/#/579bd12/416300416500
  */
 export const MAX_RECENT_HISTORY = 8;
 
@@ -26,7 +26,7 @@ export type RecentHistoryInput = {
   /**
    * `C`: BEEFY commitment.
    *
-   * https://graypaper.fluffylabs.dev/#/6e1c0cd/173d03173f03
+   * https://graypaper.fluffylabs.dev/#/579bd12/172803172a03
    */
   accumulateRoot: OpaqueHash;
   /** Work packages in the guarantees extrinsic. */
@@ -36,7 +36,7 @@ export type RecentHistoryInput = {
 /**
  * `β`: State of the blocks from recent history.
  *
- * https://graypaper.fluffylabs.dev/#/6e1c0cd/0fb7010fb701
+ * https://graypaper.fluffylabs.dev/#/579bd12/0fb7010fb701
  */
 export type RecentHistoryState = BlockState[];
 
@@ -57,7 +57,7 @@ export type BlockState = {
 /**
  * Recent History transition function.
  *
- * https://graypaper.fluffylabs.dev/#/6e1c0cd/0faf010faf01
+ * https://graypaper.fluffylabs.dev/#/579bd12/0faf010faf01
  */
 export class RecentHistory {
   constructor(

--- a/packages/trie/nodes.ts
+++ b/packages/trie/nodes.ts
@@ -11,7 +11,7 @@ export type InputKey = StateKey | TruncatedStateKey;
 /**
  * A state commitment.
  *
- * https://graypaper.fluffylabs.dev/#/387103d/0cb0000cb400
+ * https://graypaper.fluffylabs.dev/#/579bd12/0c1f010c2301
  */
 export type TrieHash = Opaque<OpaqueHash, "trie">;
 export type ValueHash = Opaque<OpaqueHash, "trieValue">;


### PR DESCRIPTION
I've manually went through all the links that `links-check` proposed and fixed the ones that were broken.
I'm not sure if we really should be doing that though, it seems that there were some links that didn't indicate they were broken, yet they were pointing to a completely unrelated part of the GP. I guess that's something to be fixed in the tool.

However, if the tool is reliable and we perform these migrations, I'd like to propose the process for this:
1. After this PR all notes will be in exact same versions.
2. When new GP is out, we can prepare a PR like that as soon as possible.
3. Any changes/broken links should be added as new issues.
4. We might consider adding some sort of `//ignore` flag to the links, so that in places where the code does not match the latest GP we keep the old version.

Alternatively we may only update the links, when someone is working/updating some code - i.e. you touch a file containing links, you should migrate them to the newer versions (and review the results). Not sure however if that will be enforceable.