### PR TITLE
Avoid commenting on forks instead of using pull_request_target

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Delete previous comment on PR
         # Don't attempt to comment if PR is coming from a fork.
         if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
           mode: delete
-          comment_tag: benchmarks
+          comment-tag: benchmarks
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -45,10 +45,10 @@ jobs:
         run: cat ./dist/benchmarks/results.txt
       - name: Comment PR
         if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          filePath: ./dist/benchmarks/results.txt
-          comment_tag: benchmarks
+          file-path: ./dist/benchmarks/results.txt
+          comment-tag: benchmarks
       - name: Upload new transaction log
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Delete previous comment on PR
         # Don't attempt to comment if PR is coming from a fork.
         if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
           mode: delete
-          comment_tag: jamtestvectors
+          comment-tag: jamtestvectors
       - uses: actions/checkout@v4
       - name: Checkout JAM test vectors
         uses: actions/checkout@v4
@@ -45,10 +45,10 @@ jobs:
       - name: Comment PR
         # Don't attempt to comment if PR is coming from a fork.
         if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          filePath: ./dist/jamtestvectors.txt
-          comment_tag: jamtestvectors
+          file-path: ./dist/jamtestvectors.txt
+          comment-tag: jamtestvectors
       - name: Upload new transaction log
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Running in `pull_request_target` will always cause us issues if we ever need to modify the workflows.

Since we really only need the token to comment on a PR (the only "unsafe" action), I've added a conditional execution there. So PRs coming from forks will just don't have the comments for now, but they will run everything in the same way.

Ideally we would split the workflows into:
1. Running the vectors/benchmarks
2. Commenting on PR

in such setup (1.) would execute in `pull_request` context, while commenting would be done in `pull_request_target` since the workflow files will be changed rarely.