### PR TITLE
Change SPI decoder to allocate whole pages

### DIFF
--- a/packages/pvm/program/program.ts
+++ b/packages/pvm/program/program.ts
@@ -1,4 +1,4 @@
-import { type Memory, MemoryBuilder } from "@typeberry/pvm-interpreter/memory";
+import { Memory, MemoryBuilder } from "@typeberry/pvm-interpreter/memory";
 import { tryAsMemoryIndex, tryAsSbrkIndex } from "@typeberry/pvm-interpreter/memory/memory-index";
 import { Registers } from "@typeberry/pvm-interpreter/registers";
 import { decodeStandardProgram } from "@typeberry/pvm-spi-decoder";
@@ -27,6 +27,12 @@ export class Program {
     const memory = memoryBuilder.finalize(heapStart, heapEnd);
 
     return new Program(code, regs, memory);
+  }
+
+  static fromGeneric(rawProgram: Uint8Array) {
+    const regs = new Registers();
+    const memory = new Memory();
+    return new Program(rawProgram, regs, memory);
   }
 
   private constructor(

--- a/packages/pvm/spi-decoder/decode-standard-program.test.ts
+++ b/packages/pvm/spi-decoder/decode-standard-program.test.ts
@@ -46,16 +46,15 @@ describe("decodeStandardProgram", () => {
     const expectedMemory = [
       {
         start: 65536,
-        end: 65540,
+        end: 69632,
         data: O,
       },
-      { start: 65540, end: 69632, data: null },
       {
         start: 4278124544,
-        end: 4278124547,
+        end: 4278128640,
         data: ARGS,
       },
-      { start: 4278124547, end: 4278128643, data: null },
+      { start: 4278128640, end: 4278132736, data: null },
     ].map(MemorySegment.from);
 
     assert.deepStrictEqual(decodedProgram.memory.readable, expectedMemory);
@@ -63,8 +62,8 @@ describe("decodeStandardProgram", () => {
 
   it("should prepare writeable memory segments", () => {
     const expectedMemory = [
-      { start: 196608, end: 196610, data: W },
-      { start: 196610, end: 212992, data: null },
+      { start: 196608, end: 200704, data: W },
+      { start: 200704, end: 212992, data: null },
       { start: 4278054912, end: 4278059008, data: null },
     ].map(MemorySegment.from);
 

--- a/packages/pvm/spi-decoder/decode-standard-program.ts
+++ b/packages/pvm/spi-decoder/decode-standard-program.ts
@@ -67,15 +67,14 @@ export function decodeStandardProgram(program: Uint8Array, args: Uint8Array) {
   decoder.finish();
 
   const readonlyDataStart = SEGMENT_SIZE;
-  const readonlyDataEnd = SEGMENT_SIZE + readOnlyLength;
-  const readOnlyZerosEnd = SEGMENT_SIZE + alignToPageSize(readOnlyLength);
+  const readonlyDataEnd = SEGMENT_SIZE + alignToPageSize(readOnlyLength);
   const heapDataStart = 2 * SEGMENT_SIZE + alignToSegmentSize(readOnlyLength);
-  const heapDataEnd = heapDataStart + heapLength;
+  const heapDataEnd = heapDataStart + alignToPageSize(heapLength);
   const heapZerosEnd = heapDataStart + alignToPageSize(heapLength) + noOfHeapZerosPages * PAGE_SIZE;
   const stackStart = STACK_SEGMENT - alignToPageSize(stackSize);
   const stackEnd = STACK_SEGMENT;
   const argsStart = ARGS_SEGMENT;
-  const argsEnd = argsStart + argsLength;
+  const argsEnd = argsStart + alignToPageSize(argsLength);
   const argsZerosEnd = argsEnd + alignToPageSize(argsLength);
 
   function nonEmpty(s: MemorySegment | false): s is MemorySegment {
@@ -84,7 +83,6 @@ export function decodeStandardProgram(program: Uint8Array, args: Uint8Array) {
 
   const readableMemory = [
     readOnlyLength > 0 && getMemorySegment(readonlyDataStart, readonlyDataEnd, readOnlyMemory),
-    readonlyDataEnd < readOnlyZerosEnd && getMemorySegment(readonlyDataEnd, readOnlyZerosEnd),
     argsLength > 0 && getMemorySegment(argsStart, argsEnd, args),
     argsEnd < argsZerosEnd && getMemorySegment(argsEnd, argsZerosEnd),
   ].filter(nonEmpty);


### PR DESCRIPTION
When I tried to decode a program from accumulation tests I spotted a problem that our SPI decoder tries to allocate segments smaller than page size (4096) and the result is rejected by `MemoryBuilder`