### PR TITLE
PVM: fix skip function

### DIFF
--- a/packages/pvm/interpreter/program-decoder/mask.test.ts
+++ b/packages/pvm/interpreter/program-decoder/mask.test.ts
@@ -53,11 +53,22 @@ describe("Mask", () => {
   });
 
   describe("getNoOfBytesToNextInstruction", () => {
-    it("should return number of 0s between two 1 in single byte", () => {
+    it("should return distance to the end of program", () => {
       const input = [0b0000_0001];
       const index = 1;
       const expectedResult = 2;
       const mask = new Mask(BitVec.fromBlob(new Uint8Array(input), 3));
+
+      const result = mask.getNoOfBytesToNextInstruction(index);
+
+      assert.strictEqual(result, expectedResult);
+    });
+
+    it("should return distance to the next instruction in single byte", () => {
+      const input = [0b0000_1001];
+      const index = 1;
+      const expectedResult = 2;
+      const mask = new Mask(BitVec.fromBlob(new Uint8Array(input), 8));
 
       const result = mask.getNoOfBytesToNextInstruction(index);
 
@@ -86,11 +97,22 @@ describe("Mask", () => {
       assert.strictEqual(result, expectedResult);
     });
 
-    it("should return number of 0s between to the end", () => {
+    it("should return distance to the end of program", () => {
       const input = [0b0001_1001];
       const index = 5;
       const expectedResult = 3;
       const mask = new Mask(BitVec.fromBlob(new Uint8Array(input), 8));
+
+      const result = mask.getNoOfBytesToNextInstruction(index);
+
+      assert.strictEqual(result, expectedResult);
+    });
+
+    it("should return MAX_INSTRUCTION_DISTANCE = 25 if the real distance is longer", () => {
+      const input = [0b0000_0001, 0b0000_0000, 0b0000_0000, 0b1000_0000];
+      const index = 1;
+      const expectedResult = 25;
+      const mask = new Mask(BitVec.fromBlob(new Uint8Array(input), input.length * 8));
 
       const result = mask.getNoOfBytesToNextInstruction(index);
 
@@ -126,6 +148,17 @@ describe("Mask", () => {
       const index = 10;
       const expectedResult = 6;
       const mask = new Mask(BitVec.fromBlob(new Uint8Array(input), 16));
+
+      const result = mask.getNoOfBytesToPreviousInstruction(index);
+
+      assert.strictEqual(result, expectedResult);
+    });
+
+    it("should return MAX_INSTRUCTION_DISTANCE = 25 if the real distance is longer", () => {
+      const input = [0b0000_0001, 0b0000_0000, 0b0000_0000, 0b1000_0000];
+      const index = 30;
+      const expectedResult = 25;
+      const mask = new Mask(BitVec.fromBlob(new Uint8Array(input), input.length * 8));
 
       const result = mask.getNoOfBytesToPreviousInstruction(index);
 

--- a/packages/pvm/interpreter/program-decoder/mask.ts
+++ b/packages/pvm/interpreter/program-decoder/mask.ts
@@ -1,5 +1,16 @@
 import { BitVec } from "@typeberry/bytes";
 import { check } from "@typeberry/utils";
+
+/**
+ * In GP it is 24 but our implementation returns skip(n) + 1
+ */
+const MAX_INSTRUCTION_DISTANCE = 25;
+
+/**
+ * Mask class is an implementation of skip function defined in GP.
+ *
+ * https://graypaper.fluffylabs.dev/#/5f542d7/237201239801
+ */
 export class Mask {
   /**
    * The lookup table will have `0` at the index which corresponds to an instruction on the same index in the bytecode.
@@ -27,7 +38,7 @@ export class Mask {
 
   getNoOfBytesToNextInstruction(index: number) {
     check(index >= 0, `index (${index}) cannot be a negative number`);
-    return this.lookupTableForward[index] ?? 0;
+    return Math.min(this.lookupTableForward[index] ?? 0, MAX_INSTRUCTION_DISTANCE);
   }
 
   getNoOfBytesToPreviousInstruction(index: number) {
@@ -36,7 +47,7 @@ export class Mask {
       index < this.lookupTableBackward.length,
       `index (${index}) cannot be bigger than ${this.lookupTableBackward.length - 1}`,
     );
-    return this.lookupTableBackward[index];
+    return Math.min(this.lookupTableBackward[index], MAX_INSTRUCTION_DISTANCE);
   }
 
   private buildLookupTableForward(mask: BitVec) {


### PR DESCRIPTION
I added `Math.min(25, ...)` to results of `getNoOfBytesToNextInstruction` and `getNoOfBytesToPreviousInstruction`. In GP this value is `24` but our function returns `GP value + 1` so I think max value should be `+ 1` as well 
  
it resolves https://github.com/FluffyLabs/typeberry/issues/67