### PR TITLE
deepEqual - fix problem with OoM

### DIFF
--- a/packages/utils/test.ts
+++ b/packages/utils/test.ts
@@ -37,7 +37,25 @@ export function deepEqual<T>(
 
   if (actual === null || expected === null || actual === undefined || expected === undefined) {
     errors.tryAndCatch(() => {
-      assert.strictEqual(actual, expected);
+      /**
+       * There is a problem with memory in node 22.12.0+
+       *
+       * This workaround can be removed when this issue is resolved: https://github.com/nodejs/node/issues/57242
+       */
+      const [major, minor] = process.versions.node.split(".").map(Number);
+      const isOoMWorkaroundNeeded = major > 22 || (major === 22 && minor >= 12);
+      const message = isOoMWorkaroundNeeded ? new Error(`${actual} != ${expected}`) : undefined;
+      if (isOoMWorkaroundNeeded) {
+        console.warn(
+          [
+            "Stacktrace may be crappy because of a problem in nodejs.",
+            "Use older version than 22.12.0 or check this issue: https://github.com/nodejs/node/issues/57242",
+            "Maybe we do not need it anymore",
+          ].join("\n"),
+        );
+      }
+
+      assert.strictEqual(actual, expected, message);
     }, ctx);
     return errors.exitOrThrow();
   }


### PR DESCRIPTION
There is a problem in nodejs 22.12.0+ that casues OoM problem. I added a simple workaround but if you have a better idea then I can improve it. 

Issue in node repo: https://github.com/nodejs/node/issues/57242

I started wondering if we need it because it is enough to change node version but I think someone else will have the same problem sooner or later so it can save time