### PR TITLE
Change jump table to accept u64 items

### DIFF
--- a/packages/core/pvm-interpreter/program-decoder/jump-table.test.ts
+++ b/packages/core/pvm-interpreter/program-decoder/jump-table.test.ts
@@ -38,7 +38,7 @@ describe("JumpTable", () => {
     assert.strictEqual(result, expectedValue);
   });
 
-  it("should load table that has u64 item that is bigger than 2 ** 32 - 1", () => {
+  it("should load jump table that has u64 item that is bigger than 2 ** 32 - 1", () => {
     const jumpTableItemLength = 8;
     const expectedValue = 0xff_ff_ff_ff;
     const bytes = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x78, 0x56, 0x34, 0x12]);
@@ -50,10 +50,23 @@ describe("JumpTable", () => {
     assert.strictEqual(result, expectedValue);
   });
 
-  it("should load table that has u64 item that is lower than 2 ** 32 - 1", () => {
+  it("should load jump table that has u64 item that is lower than 2 ** 32 - 1", () => {
     const jumpTableItemLength = 8;
     const expectedValue = 0x00_00_00_00_12_34_56_78;
     const bytes = new Uint8Array([0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0]);
+    const jumpTable = new JumpTable(jumpTableItemLength, bytes);
+    const indexToCheck = 0;
+
+    const result = jumpTable.getDestination(indexToCheck);
+
+    assert.strictEqual(result, expectedValue);
+  });
+
+  it("should load huge jump table", () => {
+    const jumpTableItemLength = 255;
+    const expectedValue = 2 ** 32 - 1;
+    const bytes = new Uint8Array(255);
+    bytes.fill(1);
     const jumpTable = new JumpTable(jumpTableItemLength, bytes);
     const indexToCheck = 0;
 

--- a/packages/core/pvm-interpreter/program-decoder/jump-table.ts
+++ b/packages/core/pvm-interpreter/program-decoder/jump-table.ts
@@ -1,4 +1,3 @@
-import { Decoder } from "@typeberry/codec";
 import { check } from "@typeberry/utils";
 
 export class JumpTable {
@@ -9,48 +8,30 @@ export class JumpTable {
       itemByteLength === 0 || bytes.length % itemByteLength === 0,
       `Length of jump table (${bytes.length}) should be a multiple of item lenght (${itemByteLength})!`,
     );
-    check(
-      itemByteLength <= 4 || itemByteLength === 8,
-      `Jump table item can be u8, u16, u24, u32 or u64. Got: u${itemByteLength * 8}}`,
-    );
 
     const length = itemByteLength === 0 ? 0 : bytes.length / itemByteLength;
 
     this.indices = new Uint32Array(length);
-    const decoder = Decoder.fromBlob(bytes);
-    let decodeNext = () => decoder.u8() as number;
-    if (itemByteLength === 8) {
-      /**
-       * GP defines jump table indices as u64 values, so it's possible to encounter
-       * programs with large jump targets. While jumps beyond 2 ** 32 (4GB) don't make
-       * practical sense—since programs can't be that large—they are still considered
-       * valid, and we must be able to load them.
-       */
-      decodeNext = () => {
-        const lowerPart = decoder.u32();
-        const higherPart = decoder.u32();
 
-        if (higherPart === 0) {
-          return Number(lowerPart);
-        }
+    for (let i = 0; i < length; i++) {
+      this.indices[i] = this.decodeNext(bytes.subarray(i * itemByteLength, (i + 1) * itemByteLength));
+    }
+  }
 
-        /**
-         * Jumping to an index >= 2 ** 32 would cause a panic
-         * so we can safely clamp it to 2 ** 32 - 1
-         */
+  private decodeNext(bytes: Uint8Array): number {
+    const itemByteLength = bytes.length;
+    let value = 0;
+
+    for (let i = 0; i < itemByteLength; i++) {
+      if ((value & 0xff00_0000) > 0) {
+        // the value is going to exceed u32 so we can clamp it
         return 2 ** 32 - 1;
-      };
-    } else if (itemByteLength === 4) {
-      decodeNext = () => decoder.u32();
-    } else if (itemByteLength === 3) {
-      decodeNext = () => decoder.u24();
-    } else if (itemByteLength === 2) {
-      decodeNext = () => decoder.u16();
+      }
+      value <<= 8;
+      value |= bytes[itemByteLength - i - 1];
     }
-    for (let i = 0; i < length; i += 1) {
-      this.indices[i] = decodeNext();
-    }
-    decoder.finish();
+
+    return value;
   }
 
   hasIndex(index: number) {


### PR DESCRIPTION
I noticed that jump table items can be u64 and we don't allow that. obviously this kind of jump will cause panic but from the other hand such programs are correct and a jump can be conditional 