### PR TITLE
Add ESLint rule to forbid relative imports from packages

### DIFF
--- a/bin/jam/extensions.ts
+++ b/bin/jam/extensions.ts
@@ -1,4 +1,4 @@
-import * as ipc from "../../extensions/ipc";
+import * as ipc from "@typeberry/ext-ipc";
 
 export function initializeExtensions(api: ipc.ExtensionApi) {
   const closeIpc = ipc.startExtension(api);

--- a/bin/jam/package.json
+++ b/bin/jam/package.json
@@ -6,8 +6,9 @@
   "dependencies": {
     "@typeberry/block-generator": "0.0.1",
     "@typeberry/config": "0.0.1",
-    "@typeberry/logger": "0.0.1",
-    "@typeberry/importer": "0.0.1"
+    "@typeberry/ext-ipc": "^0.0.1",
+    "@typeberry/importer": "0.0.1",
+    "@typeberry/logger": "0.0.1"
   },
   "scripts": {
     "start": "ts-node ./index.ts",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default tseslint.config(
           allowString: false,
         },
       ],
+      "import/no-relative-packages": "error",
     },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
       "dependencies": {
         "@typeberry/block-generator": "0.0.1",
         "@typeberry/config": "0.0.1",
+        "@typeberry/ext-ipc": "^0.0.1",
         "@typeberry/importer": "0.0.1",
         "@typeberry/logger": "0.0.1"
       }

--- a/packages/jam/transition/work-packages.ts
+++ b/packages/jam/transition/work-packages.ts
@@ -4,13 +4,13 @@ import { WorkPackageSpec, WorkReport } from "@typeberry/block/work-report";
 import { WorkExecResult, WorkExecResultKind, WorkResult } from "@typeberry/block/work-result";
 import { Bytes, BytesBlob } from "@typeberry/bytes";
 import { FixedSizeArray } from "@typeberry/collections";
+import type { BlocksDb, StateDb } from "@typeberry/database";
 import { HASH_SIZE, blake2b } from "@typeberry/hash";
 import { type U16, tryAsU32, tryAsU64 } from "@typeberry/numbers";
 import { HostCalls, PvmHostCallExtension, PvmInstanceManager } from "@typeberry/pvm-host-calls";
 import { type Gas, tryAsGas } from "@typeberry/pvm-interpreter/gas";
 import { Program } from "@typeberry/pvm-program";
 import { Result, asOpaqueType } from "@typeberry/utils";
-import type { BlocksDb, StateDb } from "../database";
 import type { TransitionHasher } from "./hasher";
 
 enum ServiceExecutorError {


### PR DESCRIPTION
Followup to https://github.com/FluffyLabs/typeberry/pull/332

# Changes
 - added [no-relative-packages](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-packages.md#importno-relative-packages) rule
 - fixed errors

<img width="1160" alt="Screenshot 2025-04-17 at 10 36 57" src="https://github.com/user-attachments/assets/0e160cc3-c3dc-4e04-b743-53b46fd7ed1e" />
