### PR TITLE
Update expected output of `Map.set` benchmark 

### DIFF
--- a/benchmarks/collections/expected/map-set.json
+++ b/benchmarks/collections/expected/map-set.json
@@ -6,14 +6,14 @@
     {
       "name": "2 gets + conditional set",
       "ops": 102951.81,
-      "margin": 0.12,
+      "margin": 0.3,
       "percentSlower": 0
     },
     {
       "name": "1 get 1 set",
-      "ops": 101387.97,
-      "margin": 0.38,
-      "percentSlower": 49.98
+      "ops": 62595.29,
+      "margin": 0.2,
+      "percentSlower": 39.2
     }
   ],
   "fastest": {


### PR DESCRIPTION
A small change to fix this:
<img width="1025" alt="Screenshot 2025-04-22 at 15 46 18" src="https://github.com/user-attachments/assets/56b20c2a-0b72-4a4d-a6bb-0260b9ab223f" />
