### PR TITLE
Disable side effects in rollup config

### DIFF
--- a/tools/builder/rollup.config.js
+++ b/tools/builder/rollup.config.js
@@ -24,6 +24,9 @@ export default [
         },
       }),
     ],
+    treeshake: {
+      moduleSideEffects: false,
+    },
   },
   {
     input: setup.typesInput,


### PR DESCRIPTION
Currently we try to load wasm in `pvm-debugger-adapter` package but we don't need it. It looks `moduleSideEffects: false,` in rollup config works (there is no wasm in bundle anymore) 