### PR TITLE
Publish commits workflow: write log artifact on errors

### DIFF
--- a/.github/workflows/blockchain-git-log.yml
+++ b/.github/workflows/blockchain-git-log.yml
@@ -44,6 +44,7 @@ jobs:
       - run: npm start
         env:
           COMMIT_KEY_SECRET: ${{ secrets.COMMIT_KEY_SECRET }}
+        continue-on-error: true
       - name: Upload new transaction log
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The log is capable of storing errors however as it stands it never gets to the point of uploading the log when an error occurs. This PR allows to upload the log artifact even when the publish step fails.