### PR TITLE
Fix anchor state root verification when anchor state root is unknown through recentBlocks state

### DIFF
--- a/bin/test-runner/w3f/reports.ts
+++ b/bin/test-runner/w3f/reports.ts
@@ -1,7 +1,6 @@
 import {
   type EntropyHash,
   type HeaderHash,
-  type StateRootHash,
   type TimeSlot,
   tryAsPerEpochBlock,
   tryAsPerValidator,
@@ -62,7 +61,7 @@ class Input {
     input: Input,
     spec: ChainSpec,
     entropy: ReportsState["entropy"],
-    priorStateRoot: StateRootHash,
+    recentBlocksPartialUpdate: ReportsState["recentBlocks"],
   ): ReportsInput {
     const view = guaranteesAsView(spec, input.guarantees, { disableCredentialsRangeCheck: true });
 
@@ -70,7 +69,7 @@ class Input {
       guarantees: view,
       slot: input.slot,
       newEntropy: entropy,
-      priorStateRoot,
+      recentBlocksPartialUpdate,
     };
   }
 }
@@ -254,7 +253,7 @@ async function runReportsTest(testContent: ReportsTest, spec: ChainSpec) {
     testContent.input,
     spec,
     preState.entropy,
-    preState.recentBlocks[preState.recentBlocks.length - 1].postStateRoot, // priorStateRoot should actually be the current header's prior state root
+    preState.recentBlocks, // note: for full fidelity this should be partially updated state, not prior state as it is now
   );
   const expectedOutput = TestReportsResult.toReportsResult(testContent.output);
 

--- a/packages/jam/transition/chain-stf.ts
+++ b/packages/jam/transition/chain-stf.ts
@@ -183,12 +183,19 @@ export class OnChain {
     } = safroleResult.ok.stateUpdate;
     assertEmpty(safroleRest);
 
+    // partial recent history
+    const recentHistoryPartialUpdate = this.recentHistory.partialTransition({
+      priorStateRoot: header.priorStateRoot,
+    });
+    const { recentBlocks: recentBlocksPartialUpdate, ...recentHistoryPartialRest } = recentHistoryPartialUpdate;
+    assertEmpty(recentHistoryPartialRest);
+
     // reports
     const reportsResult = await this.reports.transition({
       slot: timeSlot,
       guarantees: block.extrinsic.view().guarantees.view(),
       newEntropy: entropy,
-      priorStateRoot: header.priorStateRoot,
+      recentBlocksPartialUpdate,
     });
     if (reportsResult.isError) {
       return stfError(StfErrorKind.Reports, reportsResult);
@@ -273,8 +280,8 @@ export class OnChain {
 
     // recent history
     const recentHistoryUpdate = this.recentHistory.transition({
+      partial: recentHistoryPartialUpdate,
       headerHash,
-      priorStateRoot: header.priorStateRoot,
       accumulateRoot,
       workPackages,
     });

--- a/packages/jam/transition/reports/index.test.ts
+++ b/packages/jam/transition/reports/index.test.ts
@@ -5,7 +5,7 @@ import { HashDictionary, asKnownSize } from "@typeberry/collections";
 import { tinyChainSpec } from "@typeberry/config";
 import { deepEqual } from "@typeberry/utils";
 import type { ReportsInput } from "./reports.js";
-import { ENTROPY, PRIOR_STATE_ROOT, guaranteesAsView, newReports } from "./test.utils.js";
+import { ENTROPY, guaranteesAsView, newReports } from "./test.utils.js";
 
 describe("Reports - top level", () => {
   it("should perform a transition with empty state", async () => {
@@ -15,7 +15,7 @@ describe("Reports - top level", () => {
       guarantees: guaranteesAsView(tinyChainSpec, []),
       slot: tryAsTimeSlot(12),
       newEntropy: ENTROPY,
-      priorStateRoot: PRIOR_STATE_ROOT,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
     };
 
     const res = await reports.transition(input);

--- a/packages/jam/transition/reports/reports.ts
+++ b/packages/jam/transition/reports/reports.ts
@@ -1,10 +1,4 @@
-import {
-  type PerValidator,
-  type StateRootHash,
-  type TimeSlot,
-  type WorkReportHash,
-  tryAsTimeSlot,
-} from "@typeberry/block";
+import { type PerValidator, type TimeSlot, type WorkReportHash, tryAsTimeSlot } from "@typeberry/block";
 import type { GuaranteesExtrinsicView } from "@typeberry/block/guarantees.js";
 import type { WorkPackageHash, WorkPackageInfo } from "@typeberry/block/work-report.js";
 import { type BytesBlob, bytesBlobComparator } from "@typeberry/bytes";
@@ -16,6 +10,7 @@ import type { MmrHasher } from "@typeberry/mmr";
 import type { SafroleStateUpdate } from "@typeberry/safrole";
 import { AvailabilityAssignment, type State, tryAsPerCore } from "@typeberry/state";
 import { OK, Result, asOpaqueType } from "@typeberry/utils";
+import type { RecentHistoryStateUpdate } from "../recent-history.js";
 import { ReportsError } from "./error.js";
 import { generateCoreAssignment, rotationIndex } from "./guarantor-assignment.js";
 import { verifyReportsBasic } from "./verify-basic.js";
@@ -51,8 +46,8 @@ export type ReportsInput = {
   slot: TimeSlot;
   /** `eta_prime`: New entropy, after potential epoch transition. */
   newEntropy: SafroleStateUpdate["entropy"];
-  /** Prior state root of the current header. */
-  priorStateRoot: StateRootHash;
+  /** Partial update of recent blocks. (β†, https://graypaper.fluffylabs.dev/#/9a08063/0fd8010fdb01?v=0.6.6) */
+  recentBlocksPartialUpdate: RecentHistoryStateUpdate["recentBlocks"];
 };
 
 export type ReportsState = Pick<

--- a/packages/jam/transition/reports/test.utils.ts
+++ b/packages/jam/transition/reports/test.utils.ts
@@ -52,10 +52,6 @@ import { asOpaqueType } from "@typeberry/utils";
 import { Reports, type ReportsState } from "./reports.js";
 
 export const ENTROPY = getEntropy(1, 2, 3, 4);
-export const PRIOR_STATE_ROOT = Bytes.parseBytes(
-  "0xf6967658df626fa39cbfb6014b50196d23bc2cfbfa71a7591ca7715472dd2b48",
-  HASH_SIZE,
-).asOpaque();
 
 const hasher: Promise<MmrHasher<KeccakHash>> = keccak.KeccakHasher.create().then((hasher) => {
   return {

--- a/packages/jam/transition/reports/verify-contextual.test.ts
+++ b/packages/jam/transition/reports/verify-contextual.test.ts
@@ -10,15 +10,7 @@ import { HASH_SIZE } from "@typeberry/hash";
 import { NotYetAccumulatedReport } from "@typeberry/state/not-yet-accumulated.js";
 import { asOpaqueType, deepEqual } from "@typeberry/utils";
 import { ReportsError } from "./error.js";
-import {
-  ENTROPY,
-  PRIOR_STATE_ROOT,
-  guaranteesAsView,
-  initialServices,
-  newCredential,
-  newReports,
-  newWorkReport,
-} from "./test.utils.js";
+import { ENTROPY, guaranteesAsView, initialServices, newCredential, newReports, newWorkReport } from "./test.utils.js";
 
 describe("Reports.verifyContextualValidity", () => {
   it("should reject when code hash is not matching", async () => {
@@ -32,7 +24,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks, // note: for full fidelity this should be partially updated state, not prior state as it is now
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -60,7 +57,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -85,7 +87,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -111,7 +118,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -136,7 +148,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -163,7 +180,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(20_000), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(20_000),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -190,7 +212,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -219,7 +246,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -250,7 +282,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -286,7 +323,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {
@@ -315,7 +357,12 @@ describe("Reports.verifyContextualValidity", () => {
         credentials: asOpaqueType([0, 3].map((x) => newCredential(x))),
       }),
     ]);
-    const input = { slot: tryAsTimeSlot(10), guarantees, newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      slot: tryAsTimeSlot(10),
+      guarantees,
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const res = reports.verifyContextualValidity(input);
 
     deepEqual(res, {

--- a/packages/jam/transition/reports/verify-credentials.test.ts
+++ b/packages/jam/transition/reports/verify-credentials.test.ts
@@ -8,7 +8,6 @@ import { Compatibility, GpVersion, asOpaqueType, deepEqual } from "@typeberry/ut
 import { ReportsError } from "./error.js";
 import {
   ENTROPY,
-  PRIOR_STATE_ROOT,
   guaranteesAsView,
   initialValidators,
   newCredential,
@@ -31,7 +30,12 @@ describe("Reports.verifyCredentials", () => {
       { disableCredentialsRangeCheck: true },
     );
 
-    const input = { guarantees, slot: tryAsTimeSlot(1), newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      guarantees,
+      slot: tryAsTimeSlot(1),
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks, // note: for full fidelity this should be partially updated state, not prior state as it is now
+    };
     const hashes = reports.workReportHashes(guarantees);
     const res = reports.verifyCredentials(input, hashes);
 
@@ -57,7 +61,12 @@ describe("Reports.verifyCredentials", () => {
       { disableCredentialsRangeCheck: true },
     );
 
-    const input = { guarantees, slot: tryAsTimeSlot(1), newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      guarantees,
+      slot: tryAsTimeSlot(1),
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const hashes = reports.workReportHashes(guarantees);
     const res = reports.verifyCredentials(input, hashes);
 
@@ -79,7 +88,12 @@ describe("Reports.verifyCredentials", () => {
       }),
     ]);
 
-    const input = { guarantees, slot: tryAsTimeSlot(6), newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      guarantees,
+      slot: tryAsTimeSlot(6),
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const hashes = reports.workReportHashes(guarantees);
     const res = reports.verifyCredentials(input, hashes);
 
@@ -101,7 +115,12 @@ describe("Reports.verifyCredentials", () => {
       }),
     ]);
 
-    const input = { guarantees, slot: tryAsTimeSlot(6), newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      guarantees,
+      slot: tryAsTimeSlot(6),
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const hashes = reports.workReportHashes(guarantees);
     const res = reports.verifyCredentials(input, hashes);
 
@@ -123,7 +142,12 @@ describe("Reports.verifyCredentials", () => {
       }),
     ]);
 
-    const input = { guarantees, slot: tryAsTimeSlot(4), newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      guarantees,
+      slot: tryAsTimeSlot(4),
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const hashes = reports.workReportHashes(guarantees);
     const res = reports.verifyCredentials(input, hashes);
 
@@ -145,7 +169,12 @@ describe("Reports.verifyCredentials", () => {
       }),
     ]);
 
-    const input = { guarantees, slot: tryAsTimeSlot(25), newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      guarantees,
+      slot: tryAsTimeSlot(25),
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const hashes = reports.workReportHashes(guarantees);
     const res = reports.verifyCredentials(input, hashes);
 
@@ -167,7 +196,12 @@ describe("Reports.verifyCredentials", () => {
       }),
     ]);
 
-    const input = { guarantees, slot: tryAsTimeSlot(25), newEntropy: ENTROPY, priorStateRoot: PRIOR_STATE_ROOT };
+    const input = {
+      guarantees,
+      slot: tryAsTimeSlot(25),
+      newEntropy: ENTROPY,
+      recentBlocksPartialUpdate: reports.state.recentBlocks,
+    };
     const hashes = reports.workReportHashes(guarantees);
     const res = reports.verifyCredentials(input, hashes);
 


### PR DESCRIPTION
~~Since recent history is dependent on the reports transition result i couldn't use new recent history state for this fix. Hence the workaround you'll see here.~~

Updated to perform a partial update of recent history as per gp: https://graypaper.fluffylabs.dev/#/9a08063/0fe6010fe601?v=0.6.6