### PR TITLE
Fix entropy in reports

### DIFF
--- a/bin/test-runner/jamduna.ts
+++ b/bin/test-runner/jamduna.ts
@@ -23,7 +23,6 @@ main(runners, process.argv.slice(2), "test-vectors/jamduna", {
     "/chainspecs/",
     "/blocks/",
     "/state_snapshots/",
-    "orderedaccumulation/state_transitions/3_000.json",
   ],
 })
   .then((r) => logger.log(r))

--- a/packages/jam/transition/reports/reports.ts
+++ b/packages/jam/transition/reports/reports.ts
@@ -264,7 +264,7 @@ export class Reports {
 
       // if the epoch changed, we need to take previous entropy and previous validator data.
       if (isPreviousRotationPreviousEpoch(timeSlot, headerTimeSlot, epochLength)) {
-        entropy = this.state.entropy[3];
+        entropy = newEntropy[3];
         validatorData = this.state.previousValidatorData;
       }
     }


### PR DESCRIPTION
 I found one more place where we should use entropy from safrole instead of entropy from state. Now all ordered accumulation tests are green

Relates https://github.com/FluffyLabs/typeberry/pull/516