### PR TITLE
Remove outdated rule

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,9 +41,6 @@ reviews:
       instructions: |
         Casting a `bigint` (or `U64`) using `Number(x)` must have an explanation comment why
         it is safe.
-    - path: '.github/workflows/**'
-      instructions: |
-         When updating TEST_VECTORS_REF, ensure the value is identical across all files under .github/workflows/.
     - path: '**/*.ts'
       instructions: |
         When making changes to code with comments containing links (in classes, constants, methods, etc.)


### PR DESCRIPTION
We keep `TEST_VECTORS_REF` in one place so we don't need it anymore