### PR TITLE
Anyone can create db.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ USER typeberry
 # So until we have a proper TS->JS build, we probably need to live with that.
 RUN npm ci
 
+# Make sure that anyone can create a database
+RUN mkdir ./database && chmod 777 ./database
 # Make start script runable
 RUN chmod +x /app/start.sh
 


### PR DESCRIPTION
I initially thought that the issue will be fixed by just creating a non-root user, but the problem is that the system UID is propagated to docker.

On the machine I was testing this initially the `typeberry` user created inside docker was matching UID of my user on the host machine so everything was working, but it does not have to be the case.