### PR TITLE
Simple fork support

### DIFF
--- a/bin/convert/types.ts
+++ b/bin/convert/types.ts
@@ -6,6 +6,7 @@ import { blockFromJson, headerFromJson, workReportFromJson } from "@typeberry/bl
 import { type Decode, type Encode, Encoder } from "@typeberry/codec";
 import type { ChainSpec } from "@typeberry/config";
 import { JipChainSpec } from "@typeberry/config-node";
+import { messageCodec } from "@typeberry/ext-ipc/fuzz/v1/types.js";
 import { blake2b } from "@typeberry/hash";
 import type { FromJson } from "@typeberry/json-parser";
 import { decodeStandardProgram } from "@typeberry/pvm-spi-decoder";
@@ -18,7 +19,6 @@ import { StateTransition, StateTransitionGenesis } from "../test-runner/state-tr
 import { workItemFromJson } from "../test-runner/w3f/codec/work-item.js";
 import { workPackageFromJson } from "../test-runner/w3f/codec/work-package.js";
 import { PvmTest } from "../test-runner/w3f/pvm.js";
-import {messageCodec} from "@typeberry/ext-ipc/fuzz/v1/types.js";
 
 export type SupportedType = {
   name: string;

--- a/bin/convert/types.ts
+++ b/bin/convert/types.ts
@@ -18,6 +18,7 @@ import { StateTransition, StateTransitionGenesis } from "../test-runner/state-tr
 import { workItemFromJson } from "../test-runner/w3f/codec/work-item.js";
 import { workPackageFromJson } from "../test-runner/w3f/codec/work-package.js";
 import { PvmTest } from "../test-runner/w3f/pvm.js";
+import {messageCodec} from "@typeberry/ext-ipc/fuzz/v1/types.js";
 
 export type SupportedType = {
   name: string;
@@ -144,6 +145,11 @@ export const SUPPORTED_TYPES: readonly SupportedType[] = [
         }
       },
     },
+  },
+  {
+    name: "fuzz-message",
+    encode: messageCodec,
+    decode: messageCodec,
   },
 ];
 

--- a/workers/importer/importer.ts
+++ b/workers/importer/importer.ts
@@ -1,11 +1,12 @@
 import type { BlockView, EntropyHash, HeaderHash, HeaderView, TimeSlot } from "@typeberry/block";
+import { Bytes } from "@typeberry/bytes";
 import type { ChainSpec } from "@typeberry/config";
 import type { BlocksDb, LeafDb, StatesDb, StateUpdateError } from "@typeberry/database";
-import { WithHash } from "@typeberry/hash";
+import { HASH_SIZE, WithHash } from "@typeberry/hash";
 import type { Logger } from "@typeberry/logger";
 import type { SerializedState } from "@typeberry/state-merkleization";
 import type { TransitionHasher } from "@typeberry/transition";
-import { BlockVerifier, type BlockVerifierError } from "@typeberry/transition/block-verifier.js";
+import { BlockVerifier, BlockVerifierError } from "@typeberry/transition/block-verifier.js";
 import { OnChain, type StfError } from "@typeberry/transition/chain-stf.js";
 import { type ErrorResult, measure, Result, resultToString, type TaggedError } from "@typeberry/utils";
 
@@ -31,6 +32,7 @@ export class Importer {
 
   // TODO [ToDr] we cannot assume state reference does not change.
   private readonly state: SerializedState<LeafDb>;
+  private parentHash: HeaderHash;
 
   constructor(
     spec: ChainSpec,
@@ -48,6 +50,8 @@ export class Importer {
     this.verifier = new BlockVerifier(hasher, blocks);
     this.stf = new OnChain(spec, state, blocks, hasher, { enableParallelSealVerification: true });
     this.state = state;
+    this.parentHash =
+      this.blocks.getHeader(currentBestHeaderHash)?.parentHeaderHash.materialize() ?? Bytes.zero(HASH_SIZE).asOpaque();
 
     logger.info(`😎 Best time slot: ${state.timeslot} (header hash: ${currentBestHeaderHash})`);
   }
@@ -82,6 +86,21 @@ export class Importer {
       return importerError(ImporterErrorKind.Verifier, hash);
     }
 
+    // TODO [ToDr] This is incomplete/temporary fork support!
+    const parentHash = block.header.view().parentHeaderHash.materialize();
+    if (!this.parentHash.isEqualTo(parentHash)) {
+      const state = this.states.getState(parentHash);
+      if (state === null) {
+        const e = Result.error(BlockVerifierError.StateRootNotFound);
+        if (!e.isError) {
+          throw new Error("unreachable, just adding to make compiler happy");
+        }
+        return importerError(ImporterErrorKind.Verifier, e);
+      }
+      this.state.updateBackend(state?.backend);
+      this.parentHash = parentHash;
+    }
+
     const timeSlot = block.header.view().timeSlotIndex.materialize();
     const headerHash = hash.ok;
     logger.log(`🧱 Verified block: Got hash ${headerHash} for block at slot ${timeSlot}.`);
@@ -107,6 +126,7 @@ export class Importer {
     // TODO [ToDr] This is a temporary measure. We should rather read
     // the state of a parent block to support forks and create a fresh STF.
     this.state.updateBackend(newState.backend);
+    this.parentHash = parentHash;
     logger.log(timerState());
 
     // insert new state and the block to DB.


### PR DESCRIPTION
- [x] The importer can load a different state, if `parentHash` is not matching the current one (i.e. if we are not importing blocks in a sequence).