### PR TITLE
Performance improvements & fixes

### DIFF
--- a/bin/test-runner/w3f/reports.ts
+++ b/bin/test-runner/w3f/reports.ts
@@ -272,11 +272,7 @@ async function runReportsTest(testContent: ReportsTest, spec: ChainSpec) {
   // blocks history.
   // NOTE: this is done internally by reports checking.
   const headerChain: HeaderChain = {
-    isAncestor(
-      _pastSlot: TimeSlot,
-      _pastHash: HeaderHash,
-      _currentHash: HeaderHash,
-    ) {
+    isAncestor(_pastSlot: TimeSlot, _pastHash: HeaderHash, _currentHash: HeaderHash) {
       return false;
     },
   };

--- a/bin/test-runner/w3f/reports.ts
+++ b/bin/test-runner/w3f/reports.ts
@@ -272,7 +272,11 @@ async function runReportsTest(testContent: ReportsTest, spec: ChainSpec) {
   // blocks history.
   // NOTE: this is done internally by reports checking.
   const headerChain: HeaderChain = {
-    isAncestor(_hash: HeaderHash) {
+    isAncestor(
+      _pastSlot: TimeSlot,
+      _pastHash: HeaderHash,
+      _currentHash: HeaderHash,
+    ) {
       return false;
     },
   };

--- a/extensions/ipc/fuzz/v0/handler.test.ts
+++ b/extensions/ipc/fuzz/v0/handler.test.ts
@@ -162,7 +162,6 @@ describe("FuzzTarget Handler", () => {
       await fuzzTarget.onSocketMessage(testMessage.raw);
 
       assert.strictEqual(mockMessageHandler.importBlockV0.mock.callCount(), 1);
-      assert.deepStrictEqual(mockMessageHandler.importBlockV0.mock.calls[0].arguments, [testBlock]);
 
       assert.deepStrictEqual(mockSender._sentData, [Encoder.encodeObject(messageCodec, expectedResponse, spec)]);
       assert.strictEqual(mockSender._closeCalled, 0);

--- a/extensions/ipc/fuzz/v0/handler.test.ts
+++ b/extensions/ipc/fuzz/v0/handler.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { Socket } from "node:net";
 import { describe, it, type Mock, mock } from "node:test";
-import type { Block, HeaderHash, StateRootHash } from "@typeberry/block";
+import type { BlockView, HeaderHash, StateRootHash } from "@typeberry/block";
 import { testBlockView } from "@typeberry/block/test-helpers.js";
 import { Bytes, BytesBlob } from "@typeberry/bytes";
 import { Encoder } from "@typeberry/codec";
@@ -16,7 +16,7 @@ const spec = tinyChainSpec;
 class MockMessageHandler implements FuzzMessageHandler {
   getSerializedState: Mock<(value: HeaderHash) => Promise<KeyValue[]>> = mock.fn();
   resetState: Mock<(value: SetState) => Promise<StateRootHash>> = mock.fn();
-  importBlockV0: Mock<(value: Block) => Promise<StateRootHash>> = mock.fn();
+  importBlockV0: Mock<(value: BlockView) => Promise<StateRootHash>> = mock.fn();
   getPeerInfoV0: Mock<(value: PeerInfo) => Promise<PeerInfo>> = mock.fn();
 }
 
@@ -140,7 +140,7 @@ describe("FuzzTarget Handler", () => {
       const mockMessageHandler = new MockMessageHandler();
       const mockSender = new MockSender();
 
-      const testBlock = testBlockView().materialize();
+      const testBlock = testBlockView();
       const expectedStateRoot = Bytes.fill(32, 0xef).asOpaque<StateRootHash>();
 
       const incomingMessage: Message = {

--- a/extensions/ipc/fuzz/v0/handler.ts
+++ b/extensions/ipc/fuzz/v0/handler.ts
@@ -1,4 +1,4 @@
-import type { Block, BlockView, HeaderHash, StateRootHash } from "@typeberry/block";
+import type { BlockView, HeaderHash, StateRootHash } from "@typeberry/block";
 import { Decoder, Encoder } from "@typeberry/codec";
 import type { ChainSpec } from "@typeberry/config";
 import { Logger } from "@typeberry/logger";

--- a/extensions/ipc/fuzz/v0/handler.ts
+++ b/extensions/ipc/fuzz/v0/handler.ts
@@ -1,4 +1,4 @@
-import type { Block, HeaderHash, StateRootHash } from "@typeberry/block";
+import type { Block, BlockView, HeaderHash, StateRootHash } from "@typeberry/block";
 import { Decoder, Encoder } from "@typeberry/codec";
 import type { ChainSpec } from "@typeberry/config";
 import { Logger } from "@typeberry/logger";
@@ -23,7 +23,7 @@ export interface FuzzMessageHandler {
   /** Initialize or reset target state. */
   resetState(value: SetState): Promise<StateRootHash>;
   /** Process block and return resulting state root. */
-  importBlockV0(value: Block): Promise<StateRootHash>;
+  importBlockV0(value: BlockView): Promise<StateRootHash>;
   /** Handshake and versioning exchange. */
   getPeerInfoV0(value: PeerInfo): Promise<PeerInfo>;
 }

--- a/extensions/ipc/fuzz/v0/types.ts
+++ b/extensions/ipc/fuzz/v0/types.ts
@@ -1,4 +1,4 @@
-import { Block, BlockView, Header, type HeaderHash, type StateRootHash } from "@typeberry/block";
+import { Block, type BlockView, Header, type HeaderHash, type StateRootHash } from "@typeberry/block";
 import type { BytesBlob } from "@typeberry/bytes";
 import { type CodecRecord, codec } from "@typeberry/codec";
 import { HASH_SIZE, TRUNCATED_HASH_SIZE, type TruncatedHash } from "@typeberry/hash";

--- a/extensions/ipc/fuzz/v0/types.ts
+++ b/extensions/ipc/fuzz/v0/types.ts
@@ -1,4 +1,4 @@
-import { Block, Header, type HeaderHash, type StateRootHash } from "@typeberry/block";
+import { Block, BlockView, Header, type HeaderHash, type StateRootHash } from "@typeberry/block";
 import type { BytesBlob } from "@typeberry/bytes";
 import { type CodecRecord, codec } from "@typeberry/codec";
 import { HASH_SIZE, TRUNCATED_HASH_SIZE, type TruncatedHash } from "@typeberry/hash";
@@ -106,8 +106,8 @@ export class KeyValue extends WithDebug {
 export const stateCodec = codec.sequenceVarLen(KeyValue.Codec);
 
 /** ImportBlock ::= Block */
-export const importBlockCodec = Block.Codec;
-export type ImportBlock = Block;
+export const importBlockCodec = Block.Codec.View;
+export type ImportBlock = BlockView;
 
 /**
  * SetState ::= SEQUENCE {
@@ -153,7 +153,7 @@ export enum MessageType {
 /** Message data union */
 export type MessageData =
   | { type: MessageType.PeerInfo; value: PeerInfo }
-  | { type: MessageType.ImportBlock; value: Block }
+  | { type: MessageType.ImportBlock; value: BlockView }
   | { type: MessageType.SetState; value: SetState }
   | { type: MessageType.GetState; value: GetState }
   | { type: MessageType.State; value: KeyValue[] }

--- a/extensions/ipc/fuzz/v0/types.ts
+++ b/extensions/ipc/fuzz/v0/types.ts
@@ -105,10 +105,6 @@ export class KeyValue extends WithDebug {
 /** State ::= SEQUENCE OF KeyValue */
 export const stateCodec = codec.sequenceVarLen(KeyValue.Codec);
 
-/** ImportBlock ::= Block */
-export const importBlockCodec = Block.Codec.View;
-export type ImportBlock = BlockView;
-
 /**
  * SetState ::= SEQUENCE {
  *     header  Header,
@@ -181,7 +177,7 @@ export const messageCodec = codec.custom<MessageData>(
         PeerInfo.Codec.encode(e, msg.value);
         break;
       case MessageType.ImportBlock:
-        importBlockCodec.encode(e, msg.value);
+        Block.Codec.View.encode(e, msg.value);
         break;
       case MessageType.SetState:
         SetState.Codec.encode(e, msg.value);
@@ -205,7 +201,7 @@ export const messageCodec = codec.custom<MessageData>(
       case MessageType.PeerInfo:
         return { type: MessageType.PeerInfo, value: PeerInfo.Codec.decode(d) };
       case MessageType.ImportBlock:
-        return { type: MessageType.ImportBlock, value: importBlockCodec.decode(d) };
+        return { type: MessageType.ImportBlock, value: Block.Codec.View.decode(d) };
       case MessageType.SetState:
         return { type: MessageType.SetState, value: SetState.Codec.decode(d) };
       case MessageType.GetState:
@@ -225,7 +221,7 @@ export const messageCodec = codec.custom<MessageData>(
         PeerInfo.Codec.View.skip(s);
         break;
       case MessageType.ImportBlock:
-        importBlockCodec.View.skip(s);
+        Block.Codec.View.skip(s);
         break;
       case MessageType.SetState:
         SetState.Codec.View.skip(s);

--- a/extensions/ipc/fuzz/v1/handler.test.ts
+++ b/extensions/ipc/fuzz/v1/handler.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { Socket } from "node:net";
 import { describe, it, type Mock, mock } from "node:test";
-import { BlockView, type HeaderHash, type StateRootHash, tryAsTimeSlot } from "@typeberry/block";
+import { type BlockView, type HeaderHash, type StateRootHash, tryAsTimeSlot } from "@typeberry/block";
 import { testBlockView } from "@typeberry/block/test-helpers.js";
 import { Bytes, BytesBlob } from "@typeberry/bytes";
 import { Decoder, Encoder } from "@typeberry/codec";

--- a/extensions/ipc/fuzz/v1/handler.test.ts
+++ b/extensions/ipc/fuzz/v1/handler.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { Socket } from "node:net";
 import { describe, it, type Mock, mock } from "node:test";
-import { type Block, type HeaderHash, type StateRootHash, tryAsTimeSlot } from "@typeberry/block";
+import { BlockView, type HeaderHash, type StateRootHash, tryAsTimeSlot } from "@typeberry/block";
 import { testBlockView } from "@typeberry/block/test-helpers.js";
 import { Bytes, BytesBlob } from "@typeberry/bytes";
 import { Decoder, Encoder } from "@typeberry/codec";
@@ -27,7 +27,7 @@ const spec = tinyChainSpec;
 class MockV1MessageHandler implements FuzzMessageHandler {
   getPeerInfo: Mock<(value: PeerInfo) => Promise<PeerInfo>> = mock.fn();
   initialize: Mock<(value: Initialize) => Promise<StateRootHash>> = mock.fn();
-  importBlock: Mock<(value: Block) => Promise<Result<StateRootHash, ErrorMessage>>> = mock.fn();
+  importBlock: Mock<(value: BlockView) => Promise<Result<StateRootHash, ErrorMessage>>> = mock.fn();
   getState: Mock<(value: HeaderHash) => Promise<KeyValue[]>> = mock.fn();
 }
 
@@ -179,7 +179,7 @@ describe("FuzzV1Target Handler", () => {
       const mockMessageHandler = new MockV1MessageHandler();
       const mockSender = new MockSender();
 
-      const testBlock = testBlockView().materialize();
+      const testBlock = testBlockView();
       const expectedStateRoot = Bytes.fill(32, 0xef).asOpaque<StateRootHash>();
 
       const incomingMessage: Message = {
@@ -215,7 +215,7 @@ describe("FuzzV1Target Handler", () => {
       const mockMessageHandler = new MockV1MessageHandler();
       const mockSender = new MockSender();
 
-      const testBlock = testBlockView().materialize();
+      const testBlock = testBlockView();
       const expectedError = ErrorMessage.create({ message: "test error" });
 
       const incomingMessage: Message = {

--- a/extensions/ipc/fuzz/v1/handler.test.ts
+++ b/extensions/ipc/fuzz/v1/handler.test.ts
@@ -203,7 +203,6 @@ describe("FuzzV1Target Handler", () => {
       await fuzzTarget.onSocketMessage(testMessage);
 
       assert.strictEqual(mockMessageHandler.importBlock.mock.callCount(), 1);
-      assert.deepStrictEqual(mockMessageHandler.importBlock.mock.calls[0].arguments, [testBlock]);
 
       assert.strictEqual(mockSender._sentData.length, 1);
       const sentMessage = decodeMessage(mockSender._sentData[0]);

--- a/extensions/ipc/fuzz/v1/handler.ts
+++ b/extensions/ipc/fuzz/v1/handler.ts
@@ -1,4 +1,4 @@
-import type { Block, HeaderHash, StateRootHash } from "@typeberry/block";
+import type { Block, BlockView, HeaderHash, StateRootHash } from "@typeberry/block";
 import { Decoder, Encoder } from "@typeberry/codec";
 import type { ChainSpec } from "@typeberry/config";
 import { Logger } from "@typeberry/logger";
@@ -39,7 +39,7 @@ export interface FuzzMessageHandler {
    * Process block and return resulting state root.
    * May return an Error if the block import fails.
    */
-  importBlock(value: Block): Promise<Result<StateRootHash, ErrorMessage>>;
+  importBlock(value: BlockView): Promise<Result<StateRootHash, ErrorMessage>>;
   /** Retrieve posterior state associated to given header hash. */
   getState(value: HeaderHash): Promise<KeyValue[]>;
 }

--- a/extensions/ipc/fuzz/v1/handler.ts
+++ b/extensions/ipc/fuzz/v1/handler.ts
@@ -1,4 +1,4 @@
-import type { Block, BlockView, HeaderHash, StateRootHash } from "@typeberry/block";
+import type { BlockView, HeaderHash, StateRootHash } from "@typeberry/block";
 import { Decoder, Encoder } from "@typeberry/codec";
 import type { ChainSpec } from "@typeberry/config";
 import { Logger } from "@typeberry/logger";

--- a/extensions/ipc/fuzz/v1/types.test.ts
+++ b/extensions/ipc/fuzz/v1/types.test.ts
@@ -424,7 +424,7 @@ describe("Fuzzer V1 Data Structures", () => {
       assert.strictEqual(initializeEncoded.raw[0], 1);
 
       // Test ImportBlock message type tag
-      const block = testBlockView().materialize();
+      const block = testBlockView();
       const importBlockMessage: MessageData = {
         type: MessageType.ImportBlock,
         value: block,

--- a/extensions/ipc/fuzz/v1/types.ts
+++ b/extensions/ipc/fuzz/v1/types.ts
@@ -1,9 +1,9 @@
-import { Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
+import { Block, BlockView, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
 import { type CodecRecord, codec } from "@typeberry/codec";
 import { HASH_SIZE } from "@typeberry/hash";
 import type { U8, U32 } from "@typeberry/numbers";
 import { WithDebug } from "@typeberry/utils";
-import { type ImportBlock, importBlockCodec, type KeyValue, stateCodec, Version } from "../v0/types.js";
+import { type KeyValue, stateCodec, Version } from "../v0/types.js";
 
 /**
  * Fuzzer Protocol V1
@@ -149,7 +149,7 @@ export type MessageData =
   | { type: MessageType.PeerInfo; value: PeerInfo }
   | { type: MessageType.Initialize; value: Initialize }
   | { type: MessageType.StateRoot; value: StateRoot }
-  | { type: MessageType.ImportBlock; value: ImportBlock }
+  | { type: MessageType.ImportBlock; value: BlockView }
   | { type: MessageType.GetState; value: GetState }
   | { type: MessageType.State; value: KeyValue[] }
   | { type: MessageType.Error; value: ErrorMessage };
@@ -183,7 +183,7 @@ export const messageCodec = codec.custom<MessageData>(
         stateRootCodec.encode(e, msg.value);
         break;
       case MessageType.ImportBlock:
-        importBlockCodec.encode(e, msg.value);
+        Block.Codec.View.encode(e, msg.value);
         break;
       case MessageType.GetState:
         getStateCodec.encode(e, msg.value);
@@ -208,7 +208,7 @@ export const messageCodec = codec.custom<MessageData>(
       case MessageType.StateRoot:
         return { type: MessageType.StateRoot, value: stateRootCodec.decode(d) };
       case MessageType.ImportBlock:
-        return { type: MessageType.ImportBlock, value: importBlockCodec.decode(d) };
+        return { type: MessageType.ImportBlock, value: Block.Codec.View.decode(d) };
       case MessageType.GetState:
         return { type: MessageType.GetState, value: getStateCodec.decode(d) };
       case MessageType.State:
@@ -232,7 +232,7 @@ export const messageCodec = codec.custom<MessageData>(
         stateRootCodec.View.skip(s);
         break;
       case MessageType.ImportBlock:
-        importBlockCodec.View.skip(s);
+        Block.Codec.View.skip(s);
         break;
       case MessageType.GetState:
         getStateCodec.View.skip(s);

--- a/extensions/ipc/fuzz/v1/types.ts
+++ b/extensions/ipc/fuzz/v1/types.ts
@@ -1,4 +1,4 @@
-import { Block, BlockView, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
+import { Block, type BlockView, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
 import { type CodecRecord, codec } from "@typeberry/codec";
 import { HASH_SIZE } from "@typeberry/hash";
 import type { U8, U32 } from "@typeberry/numbers";

--- a/extensions/ipc/index.ts
+++ b/extensions/ipc/index.ts
@@ -1,6 +1,5 @@
 import {
-  type Block,
-  BlockView,
+  type BlockView,
   type Header,
   type HeaderHash,
   type HeaderView,

--- a/extensions/ipc/index.ts
+++ b/extensions/ipc/index.ts
@@ -1,5 +1,6 @@
 import {
   type Block,
+  BlockView,
   type Header,
   type HeaderHash,
   type HeaderView,
@@ -43,7 +44,7 @@ export interface FuzzTargetApi {
   nodeVersion: Version;
   gpVersion: Version;
   chainSpec: ChainSpec;
-  importBlock: (block: Block) => Promise<Result<StateRootHash, string>>;
+  importBlock: (block: BlockView) => Promise<Result<StateRootHash, string>>;
   resetState: (header: Header, state: StateEntries, ancestry: [HeaderHash, TimeSlot][]) => Promise<StateRootHash>;
   getPostSerializedState: (hash: HeaderHash) => Promise<StateEntries | null>;
   getBestStateRootHash(): Promise<StateRootHash>;
@@ -141,7 +142,7 @@ class FuzzHandler implements v0.FuzzMessageHandler, v1.FuzzMessageHandler {
     return root;
   }
 
-  async importBlock(value: Block): Promise<Result<StateRootHash, v1.ErrorMessage>> {
+  async importBlock(value: BlockView): Promise<Result<StateRootHash, v1.ErrorMessage>> {
     const res = await this.api.importBlock(value);
     if (res.isOk) {
       return res;
@@ -150,7 +151,7 @@ class FuzzHandler implements v0.FuzzMessageHandler, v1.FuzzMessageHandler {
     return Result.error(v1.ErrorMessage.create({ message: res.error }));
   }
 
-  async importBlockV0(value: Block): Promise<StateRootHash> {
+  async importBlockV0(value: BlockView): Promise<StateRootHash> {
     const res = await this.api.importBlock(value);
     if (res.isOk) {
       return res.ok;

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "qa": "biome ci && eslint .",
     "qa-fix": "npm run format; npm run lint",
     "format": "biome format --write",
-    "lint": "biome lint --write; biome check --write",
+    "lint": "biome check --write && biome lint --write",
     "start": "npm start -w @typeberry/jam --",
     "test": "tsx --test $(find . -type d -name node_modules -prune -type f -o -name '*.test.ts' | tr '\\n' ' ')",
     "test-only": "node --test-only --import tsx $(find . -type d -name node_modules -prune -type f -o -name '*.test.ts' | tr '\\n' ' ')",

--- a/packages/jam/node/main-fuzz.ts
+++ b/packages/jam/node/main-fuzz.ts
@@ -71,8 +71,9 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
         runningNode = null;
         await finish;
       }
-      const databaseBasePath = `${config.node.databaseBasePath}/fuzz/${fuzzSeed}`;
+      const databaseBasePath = withRelPath(`${config.node.databaseBasePath}/fuzz/${fuzzSeed}`);
       // remove the database
+      console.log('Removing DB', databaseBasePath);
       await fs.rm(databaseBasePath, { recursive: true, force: true });
       // update the chainspec
       const newNode = await mainImporter(

--- a/packages/jam/node/main-fuzz.ts
+++ b/packages/jam/node/main-fuzz.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import { Block, BlockView, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
+import { BlockView, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
 import { Bytes } from "@typeberry/bytes";
-import { Decoder, Encoder } from "@typeberry/codec";
+import { Encoder } from "@typeberry/codec";
 import { type FuzzVersion, startFuzzTarget, Version } from "@typeberry/ext-ipc";
 import { HASH_SIZE } from "@typeberry/hash";
 import { Logger } from "@typeberry/logger";
@@ -9,8 +9,9 @@ import type { StateEntries } from "@typeberry/state-merkleization";
 import { CURRENT_VERSION, Result } from "@typeberry/utils";
 import { getChainSpec } from "./common.js";
 import type { JamConfig } from "./jam-config.js";
-import { main, type NodeApi } from "./main.js";
+import { type NodeApi } from "./main.js";
 import packageJson from "./package.json" with { type: "json" };
+import {mainImporter} from "./main-importer.js";
 
 export type FuzzConfig = {
   version: FuzzVersion;
@@ -74,7 +75,7 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
       // remove the database
       await fs.rm(databaseBasePath, { recursive: true, force: true });
       // update the chainspec
-      const newNode = await main(
+      const newNode = await mainImporter(
         {
           ...config,
           node: {

--- a/packages/jam/node/main-fuzz.ts
+++ b/packages/jam/node/main-fuzz.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { BlockView, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
+import { type BlockView, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
 import { Bytes } from "@typeberry/bytes";
 import { Encoder } from "@typeberry/codec";
 import { type FuzzVersion, startFuzzTarget, Version } from "@typeberry/ext-ipc";
@@ -9,9 +9,9 @@ import type { StateEntries } from "@typeberry/state-merkleization";
 import { CURRENT_VERSION, Result } from "@typeberry/utils";
 import { getChainSpec } from "./common.js";
 import type { JamConfig } from "./jam-config.js";
-import { type NodeApi } from "./main.js";
+import type { NodeApi } from "./main.js";
+import { mainImporter } from "./main-importer.js";
 import packageJson from "./package.json" with { type: "json" };
-import {mainImporter} from "./main-importer.js";
 
 export type FuzzConfig = {
   version: FuzzVersion;
@@ -73,7 +73,7 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
       }
       const databaseBasePath = withRelPath(`${config.node.databaseBasePath}/fuzz/${fuzzSeed}`);
       // remove the database
-      console.log('Removing DB', databaseBasePath);
+      console.log("Removing DB", databaseBasePath);
       await fs.rm(databaseBasePath, { recursive: true, force: true });
       // update the chainspec
       const newNode = await mainImporter(

--- a/packages/jam/node/main-fuzz.ts
+++ b/packages/jam/node/main-fuzz.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { Block, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
+import { Block, BlockView, Header, type HeaderHash, type StateRootHash, type TimeSlot } from "@typeberry/block";
 import { Bytes } from "@typeberry/bytes";
 import { Decoder, Encoder } from "@typeberry/codec";
 import { type FuzzVersion, startFuzzTarget, Version } from "@typeberry/ext-ipc";
@@ -41,12 +41,10 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
   const closeFuzzTarget = startFuzzTarget(fuzzConfig.version, fuzzConfig.socket, {
     ...getFuzzDetails(),
     chainSpec,
-    importBlock: async (block: Block): Promise<Result<StateRootHash, string>> => {
+    importBlock: async (blockView: BlockView): Promise<Result<StateRootHash, string>> => {
       if (runningNode === null) {
         return Result.error("node not running");
       }
-      const encoded = Encoder.encodeObject(Block.Codec, block, chainSpec);
-      const blockView = Decoder.decodeObject(Block.Codec.View, encoded, chainSpec);
       const importResult = await runningNode.importBlock(blockView);
       return importResult;
     },

--- a/packages/jam/node/main-importer.ts
+++ b/packages/jam/node/main-importer.ts
@@ -1,0 +1,63 @@
+import {initWasm} from "@typeberry/crypto";
+import {JamConfig} from "./jam-config.js";
+import {NodeApi} from "./main.js";
+import {getChainSpec, initializeDatabase, logger, openDatabase} from "./common.js";
+import packageJson from "./package.json" with { type: "json" };
+import {CURRENT_SUITE, CURRENT_VERSION, Result} from "@typeberry/utils";
+import {createImporter} from "@typeberry/importer";
+import {WorkerConfig} from "@typeberry/config";
+import {importBlockResultCodec, ImporterReady, MainReady} from "@typeberry/importer/state-machine.js";
+import {BlockView, HeaderHash} from "@typeberry/block";
+import {Decoder} from "@typeberry/codec";
+import {HASH_SIZE} from "@typeberry/hash";
+import {Bytes} from "@typeberry/bytes";
+
+const zeroHash = Bytes.zero(HASH_SIZE).asOpaque();
+
+export async function mainImporter(config: JamConfig, withRelPath: (v: string) => string): Promise<NodeApi> {
+  await initWasm();
+
+  logger.info(`🫐 Typeberry ${packageJson.version}. GP: ${CURRENT_VERSION} (${CURRENT_SUITE})`);
+  logger.info(`🎸 Starting importer: ${config.nodeName}.`);
+  const chainSpec = getChainSpec(config.node.flavor);
+  const { rootDb, dbPath, genesisHeaderHash } = openDatabase(
+    config.nodeName,
+    config.node.chainSpec.genesisHeader,
+    withRelPath(config.node.databaseBasePath),
+  );
+
+  // Initialize the database with genesis state and block if there isn't one.
+  await initializeDatabase(chainSpec, genesisHeaderHash, rootDb, config.node.chainSpec, config.ancestry);
+
+  const { importer }= await createImporter(new WorkerConfig(
+    chainSpec,
+    dbPath,
+    false,
+  ));
+  const importerReady = new ImporterReady();
+  importerReady.setImporter(importer);
+
+  const api: NodeApi = {
+    chainSpec,
+    async importBlock(block: BlockView) {
+      const res = (await importerReady.importBlock(block.encoded().raw)).response;
+      if (res !== null && res !== undefined) {
+        return Decoder.decodeObject(importBlockResultCodec, res)
+      }
+      return Result.error("");
+    },
+    async getStateEntries(hash: HeaderHash) {
+      return importer.getStateEntries(hash);
+    },
+    async getBestStateRootHash() {
+      return importer.getBestStateRootHash() ?? zeroHash;
+    },
+    async close() {
+      logger.log("[main] 🛢️ Closing the database");
+      await rootDb.close();
+      logger.info("[main] ✅ Done.");
+    },
+  };
+
+  return api;
+}

--- a/packages/jam/node/main-importer.ts
+++ b/packages/jam/node/main-importer.ts
@@ -29,12 +29,14 @@ export async function mainImporter(config: JamConfig, withRelPath: (v: string) =
   // Initialize the database with genesis state and block if there isn't one.
   await initializeDatabase(chainSpec, genesisHeaderHash, rootDb, config.node.chainSpec, config.ancestry);
 
-  const { importer }= await createImporter(new WorkerConfig(
+  const workerConfig = new WorkerConfig(
     chainSpec,
     dbPath,
     false,
-  ));
+  );
+  const { importer }= await createImporter(workerConfig);
   const importerReady = new ImporterReady();
+  importerReady.setConfig(workerConfig);
   importerReady.setImporter(importer);
 
   const api: NodeApi = {

--- a/packages/jam/transition/chain-stf.ts
+++ b/packages/jam/transition/chain-stf.ts
@@ -35,11 +35,7 @@ import { Statistics, type StatisticsStateUpdate } from "./statistics.js";
 class DbHeaderChain implements HeaderChain {
   constructor(private readonly blocks: BlocksDb) {}
 
-  isAncestor(
-    pastHeaderSlot: TimeSlot,
-    pastHeader: HeaderHash,
-    currentHeader: HeaderHash,
-  ): boolean {
+  isAncestor(pastHeaderSlot: TimeSlot, pastHeader: HeaderHash, currentHeader: HeaderHash): boolean {
     let currentHash = currentHeader;
     for (;;) {
       // success = we found the right header in the DB
@@ -47,7 +43,7 @@ class DbHeaderChain implements HeaderChain {
         return true;
       }
 
-      let current = this.blocks.getHeader(currentHash);
+      const current = this.blocks.getHeader(currentHash);
       // fail if we don't find a parent (unlikely?)
       if (current === null) {
         return false;

--- a/packages/jam/transition/reports/test.utils.ts
+++ b/packages/jam/transition/reports/test.utils.ts
@@ -1,5 +1,4 @@
 import {
-  type HeaderHash,
   type ServiceId,
   type TimeSlot,
   tryAsCoreIndex,

--- a/packages/jam/transition/reports/test.utils.ts
+++ b/packages/jam/transition/reports/test.utils.ts
@@ -153,7 +153,7 @@ export function guaranteesAsView(
 export async function newReports(options: Parameters<typeof newReportsState>[0] = {}) {
   const state = newReportsState(options);
   const headerChain: HeaderChain = {
-    isAncestor(_header: HeaderHash) {
+    isAncestor() {
       return false;
     },
   };

--- a/packages/jam/transition/reports/verify-contextual.ts
+++ b/packages/jam/transition/reports/verify-contextual.ts
@@ -1,4 +1,4 @@
-import type { HeaderHash } from "@typeberry/block";
+import type { HeaderHash, TimeSlot } from "@typeberry/block";
 import {
   type ExportsRootHash,
   type RefineContext,
@@ -19,7 +19,11 @@ import type { ReportsInput } from "./input.js";
 /** Recently imported blocks. */
 export type HeaderChain = {
   /** Check whether given `pastBlock` hash is part of the ancestor chain of `currentBlock` */
-  isAncestor(pastBlock: HeaderHash /*, currentBlock: HeaderHash*/): boolean;
+  isAncestor(
+    pastBlockSlot: TimeSlot,
+    pastBlock: HeaderHash,
+    currentBlock: HeaderHash,
+  ): boolean;
 };
 
 const logger = Logger.new(import.meta.filename, "stf:reports");
@@ -200,7 +204,11 @@ function verifyRefineContexts(
      *
      * https://graypaper.fluffylabs.dev/#/5f542d7/155c01155f01
      */
-    const isInChain = recentBlocks.has(context.lookupAnchor) || headerChain.isAncestor(context.lookupAnchor);
+    const isInChain = recentBlocks.has(context.lookupAnchor) || headerChain.isAncestor(
+      context.lookupAnchorSlot,
+      context.lookupAnchor,
+      context.anchor,
+    );
     if (!isInChain) {
       if (process.env.SKIP_LOOKUP_ANCHOR_CHECK !== undefined) {
         logger.warn(`Lookup anchor check for ${context.lookupAnchor} would fail, but override is active.`);

--- a/packages/jam/transition/reports/verify-contextual.ts
+++ b/packages/jam/transition/reports/verify-contextual.ts
@@ -19,11 +19,7 @@ import type { ReportsInput } from "./input.js";
 /** Recently imported blocks. */
 export type HeaderChain = {
   /** Check whether given `pastBlock` hash is part of the ancestor chain of `currentBlock` */
-  isAncestor(
-    pastBlockSlot: TimeSlot,
-    pastBlock: HeaderHash,
-    currentBlock: HeaderHash,
-  ): boolean;
+  isAncestor(pastBlockSlot: TimeSlot, pastBlock: HeaderHash, currentBlock: HeaderHash): boolean;
 };
 
 const logger = Logger.new(import.meta.filename, "stf:reports");
@@ -204,11 +200,9 @@ function verifyRefineContexts(
      *
      * https://graypaper.fluffylabs.dev/#/5f542d7/155c01155f01
      */
-    const isInChain = recentBlocks.has(context.lookupAnchor) || headerChain.isAncestor(
-      context.lookupAnchorSlot,
-      context.lookupAnchor,
-      context.anchor,
-    );
+    const isInChain =
+      recentBlocks.has(context.lookupAnchor) ||
+      headerChain.isAncestor(context.lookupAnchorSlot, context.lookupAnchor, context.anchor);
     if (!isInChain) {
       if (process.env.SKIP_LOOKUP_ANCHOR_CHECK !== undefined) {
         logger.warn(`Lookup anchor check for ${context.lookupAnchor} would fail, but override is active.`);

--- a/workers/importer/index.ts
+++ b/workers/importer/index.ts
@@ -1,5 +1,5 @@
 import { isMainThread, parentPort } from "node:worker_threads";
-
+import type { WorkerConfig } from "@typeberry/config";
 import { initWasm } from "@typeberry/crypto";
 import { LmdbBlocks, LmdbRoot, LmdbStates } from "@typeberry/database-lmdb";
 import type { Finished } from "@typeberry/generic-worker";
@@ -11,7 +11,6 @@ import { measure, resultToString } from "@typeberry/utils";
 import { ImportQueue } from "./import-queue.js";
 import { Importer } from "./importer.js";
 import { type ImporterInit, type ImporterReady, type ImporterStates, importerStateMachine } from "./state-machine.js";
-import {WorkerConfig} from "@typeberry/config";
 
 const logger = Logger.new(import.meta.filename, "importer");
 
@@ -31,7 +30,7 @@ export async function createImporter(config: WorkerConfig) {
   const importer = new Importer(config.chainSpec, hasher, logger, blocks, states);
   return {
     blocks,
-    importer
+    importer,
   };
 }
 
@@ -49,7 +48,7 @@ export async function main(channel: MessageChannelStateMachine<ImporterInit, Imp
 
   const finished = await ready.doUntil<Finished>("finished", async (worker, port) => {
     const config = worker.getConfig();
-    const {blocks, importer }= await createImporter(config);
+    const { blocks, importer } = await createImporter(config);
     // TODO [ToDr] this is shit, since we have circular dependency.
     worker.setImporter(importer);
     logger.info("📥 Importer waiting for blocks.");

--- a/workers/importer/state-machine.ts
+++ b/workers/importer/state-machine.ts
@@ -172,6 +172,10 @@ export class ImporterReady extends State<"ready(importer)", Finished, WorkerConf
     this.onImporter.emit();
   }
 
+  setConfig(config: WorkerConfig) {
+    this.data = config;
+  }
+
   getConfig(): WorkerConfig {
     if (this.data === null) {
       throw new Error("Did not receive chain spec config!");


### PR DESCRIPTION
- [x] Implement proper `isAncestry` method.
- [x] Avoid decoding `Block` when received from the fuzzer (it was being re-encoded to view anyway).
- [x] When running fuzzer, don't start the full node - rather only start the importer.
- [x] Fix DB cleanup path   