### PR TITLE
fix order of transfers

### DIFF
--- a/packages/jam/transition/accumulate/deferred-transfers.ts
+++ b/packages/jam/transition/accumulate/deferred-transfers.ts
@@ -62,13 +62,16 @@ export class DeferredTransfers {
   }: DeferredTransfersInput): Promise<Result<DeferredTransfersResult, DeferredTransfersErrorCode>> {
     // https://graypaper.fluffylabs.dev/#/7e6ff6a/187a03187a03?v=0.6.7
     const transferStatistics = new Map<ServiceId, CountAndGasUsed>();
-    const services = uniquePreserveOrder(pendingTransfers.flatMap((x) => [x.source, x.destination]));
+    const services = uniquePreserveOrder(pendingTransfers.map((x) => x.destination));
 
     let currentStateUpdate = AccumulationStateUpdate.new(inputServicesUpdate);
 
     for (const serviceId of services) {
       const partiallyUpdatedState = new PartiallyUpdatedState(this.state, currentStateUpdate);
-      const transfers = pendingTransfers.filter((pendingTransfer) => pendingTransfer.destination === serviceId);
+      // https://graypaper.fluffylabs.dev/#/38c4e62/18750318ae03?v=0.7.0
+      const transfers = pendingTransfers
+        .filter((pendingTransfer) => pendingTransfer.destination === serviceId)
+        .toSorted((a, b) => a.source - b.source);
 
       const info = partiallyUpdatedState.getServiceInfo(serviceId);
       if (info === null) {


### PR DESCRIPTION
I fixed the order of transfers. According to GP:

> Furthermore we build the deferred transfers statistics value X as the number of transfers and the total gas used in transfer processing for each destination service index.

https://graypaper.fluffylabs.dev/#/38c4e62/183304188704?v=0.7.0

