### PR TITLE
Quicker dispute membership queries

### DIFF
--- a/packages/jam/state/disputes.ts
+++ b/packages/jam/state/disputes.ts
@@ -1,6 +1,11 @@
 import type { WorkReportHash } from "@typeberry/block";
 import { type CodecRecord, codec, readonlyArray } from "@typeberry/codec";
-import { type ImmutableSortedSet, SortedSet } from "@typeberry/collections";
+import {
+  HashDictionary,
+  type ImmutableHashDictionary,
+  type ImmutableSortedSet,
+  SortedSet,
+} from "@typeberry/collections";
 import type { Ed25519Key } from "@typeberry/crypto";
 import { HASH_SIZE, type OpaqueHash } from "@typeberry/hash";
 
@@ -31,6 +36,11 @@ export class DisputesRecords {
     return new DisputesRecords(goodSet, badSet, wonkySet, punishSet);
   }
 
+  private readonly goodSetDict: ImmutableHashDictionary<WorkReportHash, true>;
+  private readonly badSetDict: ImmutableHashDictionary<WorkReportHash, true>;
+  private readonly wonkySetDict: ImmutableHashDictionary<WorkReportHash, true>;
+  private readonly punishSetDict: ImmutableHashDictionary<Ed25519Key, true>;
+
   private constructor(
     /** `goodSet`: all work-reports hashes which were judged to be correct */
     public readonly goodSet: ImmutableSortedSet<WorkReportHash>,
@@ -40,7 +50,21 @@ export class DisputesRecords {
     public readonly wonkySet: ImmutableSortedSet<WorkReportHash>,
     /** `punishSet`: set of Ed25519 keys representing validators which were found to have misjudged a work-report */
     public readonly punishSet: ImmutableSortedSet<Ed25519Key>,
-  ) {}
+  ) {
+    this.goodSetDict = HashDictionary.fromEntries(goodSet.array.map((x) => [x, true]));
+    this.badSetDict = HashDictionary.fromEntries(badSet.array.map((x) => [x, true]));
+    this.wonkySetDict = HashDictionary.fromEntries(wonkySet.array.map((x) => [x, true]));
+    this.punishSetDict = HashDictionary.fromEntries(punishSet.array.map((x) => [x, true]));
+  }
+
+  public asDictionaries() {
+    return {
+      goodSet: this.goodSetDict,
+      badSet: this.badSetDict,
+      wonkySet: this.wonkySetDict,
+      punishSet: this.punishSetDict,
+    };
+  }
 
   static fromSortedArrays({
     goodSet,

--- a/packages/jam/state/disputes.ts
+++ b/packages/jam/state/disputes.ts
@@ -1,11 +1,6 @@
 import type { WorkReportHash } from "@typeberry/block";
 import { type CodecRecord, codec, readonlyArray } from "@typeberry/codec";
-import {
-  HashDictionary,
-  type ImmutableHashDictionary,
-  type ImmutableSortedSet,
-  SortedSet,
-} from "@typeberry/collections";
+import { HashSet, type ImmutableHashSet, type ImmutableSortedSet, SortedSet } from "@typeberry/collections";
 import type { Ed25519Key } from "@typeberry/crypto";
 import { HASH_SIZE, type OpaqueHash } from "@typeberry/hash";
 
@@ -36,10 +31,10 @@ export class DisputesRecords {
     return new DisputesRecords(goodSet, badSet, wonkySet, punishSet);
   }
 
-  private readonly goodSetDict: ImmutableHashDictionary<WorkReportHash, true>;
-  private readonly badSetDict: ImmutableHashDictionary<WorkReportHash, true>;
-  private readonly wonkySetDict: ImmutableHashDictionary<WorkReportHash, true>;
-  private readonly punishSetDict: ImmutableHashDictionary<Ed25519Key, true>;
+  private readonly goodSetDict: ImmutableHashSet<WorkReportHash>;
+  private readonly badSetDict: ImmutableHashSet<WorkReportHash>;
+  private readonly wonkySetDict: ImmutableHashSet<WorkReportHash>;
+  private readonly punishSetDict: ImmutableHashSet<Ed25519Key>;
 
   private constructor(
     /** `goodSet`: all work-reports hashes which were judged to be correct */
@@ -51,10 +46,10 @@ export class DisputesRecords {
     /** `punishSet`: set of Ed25519 keys representing validators which were found to have misjudged a work-report */
     public readonly punishSet: ImmutableSortedSet<Ed25519Key>,
   ) {
-    this.goodSetDict = HashDictionary.fromEntries(goodSet.array.map((x) => [x, true]));
-    this.badSetDict = HashDictionary.fromEntries(badSet.array.map((x) => [x, true]));
-    this.wonkySetDict = HashDictionary.fromEntries(wonkySet.array.map((x) => [x, true]));
-    this.punishSetDict = HashDictionary.fromEntries(punishSet.array.map((x) => [x, true]));
+    this.goodSetDict = HashSet.from(goodSet.array);
+    this.badSetDict = HashSet.from(badSet.array);
+    this.wonkySetDict = HashSet.from(wonkySet.array);
+    this.punishSetDict = HashSet.from(punishSet.array);
   }
 
   public asDictionaries() {

--- a/packages/jam/transition/disputes/disputes.ts
+++ b/packages/jam/transition/disputes/disputes.ts
@@ -29,6 +29,9 @@ type NewDisputesRecordsItems = {
   toAddToGoodSet: SortedSet<WorkReportHash>;
   toAddToBadSet: SortedSet<WorkReportHash>;
   toAddToWonkySet: SortedSet<WorkReportHash>;
+  toAddToGoodSetDict: HashDictionary<WorkReportHash, true>;
+  toAddToBadSetDict: HashDictionary<WorkReportHash, true>;
+  toAddToWonkySetDict: HashDictionary<WorkReportHash, true>;
 };
 
 type Ok = null;
@@ -55,7 +58,7 @@ export class Disputes {
       const { key, workReportHash } = disputes.culprits[i];
       // check if some offenders weren't reported earlier
       // https://graypaper.fluffylabs.dev/#/579bd12/125501125501
-      const isInPunishSet = this.state.disputesRecords.punishSet.findExact(key) !== undefined;
+      const isInPunishSet = this.state.disputesRecords.asDictionaries().punishSet.get(key) !== undefined;
       if (isInPunishSet) {
         return Result.error(DisputesErrorCode.OffenderAlreadyReported);
       }
@@ -68,7 +71,7 @@ export class Disputes {
 
       // verify if the culprit will be in new bad set
       // https://graypaper.fluffylabs.dev/#/579bd12/124601124601
-      const isInNewBadSet = newItems.toAddToBadSet.findExact(workReportHash);
+      const isInNewBadSet = newItems.toAddToBadSetDict.get(workReportHash);
       if (isInNewBadSet === undefined) {
         return Result.error(DisputesErrorCode.CulpritsVerdictNotBad);
       }
@@ -101,7 +104,7 @@ export class Disputes {
       const { key, workReportHash, wasConsideredValid } = disputes.faults[i];
       // check if some offenders weren't reported earlier
       // https://graypaper.fluffylabs.dev/#/579bd12/12a20112a201
-      const isInPunishSet = this.state.disputesRecords.punishSet.findExact(key) !== undefined;
+      const isInPunishSet = this.state.disputesRecords.asDictionaries().punishSet.get(key) !== undefined;
 
       if (isInPunishSet) {
         return Result.error(DisputesErrorCode.OffenderAlreadyReported);
@@ -119,8 +122,8 @@ export class Disputes {
       // but it does not pass the tests
       // https://graypaper.fluffylabs.dev/#/579bd12/128a01129601
       if (wasConsideredValid) {
-        const isInNewGoodSet = newItems.toAddToGoodSet.findExact(workReportHash);
-        const isInNewBadSet = newItems.toAddToBadSet.findExact(workReportHash);
+        const isInNewGoodSet = newItems.toAddToGoodSetDict.get(workReportHash);
+        const isInNewBadSet = newItems.toAddToBadSetDict.get(workReportHash);
 
         if (isInNewGoodSet !== undefined || isInNewBadSet === undefined) {
           return Result.error(DisputesErrorCode.FaultVerdictWrong);
@@ -188,9 +191,9 @@ export class Disputes {
     for (const verdict of disputes.verdicts) {
       // current verdicts should not be reported earlier
       // https://graypaper.fluffylabs.dev/#/579bd12/122202122202
-      const isInGoodSet = this.state.disputesRecords.goodSet.findExact(verdict.workReportHash);
-      const isInBadSet = this.state.disputesRecords.badSet.findExact(verdict.workReportHash);
-      const isInWonkySet = this.state.disputesRecords.wonkySet.findExact(verdict.workReportHash);
+      const isInGoodSet = this.state.disputesRecords.asDictionaries().goodSet.get(verdict.workReportHash);
+      const isInBadSet = this.state.disputesRecords.asDictionaries().badSet.get(verdict.workReportHash);
+      const isInWonkySet = this.state.disputesRecords.asDictionaries().wonkySet.get(verdict.workReportHash);
 
       if (isInGoodSet !== undefined || isInBadSet !== undefined || isInWonkySet !== undefined) {
         return Result.error(DisputesErrorCode.AlreadyJudged);
@@ -277,6 +280,9 @@ export class Disputes {
       toAddToGoodSet: SortedSet.fromArrayUnique(hashComparator, toAddToGoodSet),
       toAddToBadSet: SortedSet.fromArrayUnique(hashComparator, toAddToBadSet),
       toAddToWonkySet: SortedSet.fromArrayUnique(hashComparator, toAddToWonkySet),
+      toAddToGoodSetDict: HashDictionary.fromEntries<WorkReportHash, true>(toAddToGoodSet.map((r) => [r, true])),
+      toAddToBadSetDict: HashDictionary.fromEntries<WorkReportHash, true>(toAddToBadSet.map((r) => [r, true])),
+      toAddToWonkySetDict: HashDictionary.fromEntries<WorkReportHash, true>(toAddToWonkySet.map((r) => [r, true])),
     };
   }
 


### PR DESCRIPTION
Fixes #195 

Average execution time of disputes transition in davxy 0.7.0 test vectors:

| method | average (ms) |
|  --- | --- |
| Using .find() | 13.1597516 ms |
| Using HashDictionaries | 11.47134053 ms |