### PR TITLE
Fix release to npm

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Publish @typeberry/${{ matrix.project }} to npm
       working-directory: ./dist/${{ matrix.project }}
       env:
-        IS_RELEASE: ${{ github.event_name == 'release' }}
+        IS_RELEASE: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: npm publish --access=public --tag $([ "$IS_RELEASE" = "true" ] && echo "latest" || echo "next")
 


### PR DESCRIPTION
In the release workflow, the env variable was missing, so the latest `0.1.3` is released with `next` instead of `latest` tag on npm.

Hence `npx @typeberry/jam@latest` will still install `0.1.2-sth`