### PR TITLE
Annotated known problem with 0.7.1 trace

### DIFF
--- a/bin/test-runner/w3f-davxy-071.ts
+++ b/bin/test-runner/w3f-davxy-071.ts
@@ -8,7 +8,9 @@ main(runners, process.argv.slice(2), "test-vectors/w3f-davxy_071", {
   },
   ignored: [
     "genesis.json",
-    "fuzzy/00000037", // statistics + afew
+
+    // NOTE: Running parallel accumulation should fix this test.
+    "fuzzy/00000037", // incorrect onTransferMinGas retrieved from Info HC of another service
   ],
 })
   .then((r) => logger.log`${r}`)


### PR DESCRIPTION
`TRACE [host-calls] INFO(1809622606, off: 56, len: 8) <- 0x0000000000000000`
shopuld be
`TRACE [host-calls] INFO(1809622606, off: 56, len: 8) <- 0x890d000000000000`