### PR TITLE
remove Compatibility.isLessThan

### DIFF
--- a/packages/core/utils/compatibility.test.ts
+++ b/packages/core/utils/compatibility.test.ts
@@ -36,15 +36,6 @@ describe("GrayPaper compatibility", { concurrency: false }, () => {
     assert.equal(Compatibility.isGreaterOrEqual(GpVersion.V0_7_2), false);
   });
 
-  it("Should check an order of versions (isLessThan)", () => {
-    const gpVersion = GpVersion.V0_7_0;
-    Compatibility.override(gpVersion);
-
-    assert.equal(Compatibility.isLessThan(GpVersion.V0_7_2), true);
-    assert.equal(Compatibility.isLessThan(GpVersion.V0_7_1), true);
-    assert.equal(Compatibility.isLessThan(GpVersion.V0_7_0), false);
-  });
-
   it("Should order values by versions and get the one for highest version matching", () => {
     const gpVersion = GpVersion.V0_7_1;
     Compatibility.override(gpVersion);

--- a/packages/core/utils/compatibility.ts
+++ b/packages/core/utils/compatibility.ts
@@ -80,10 +80,6 @@ export class Compatibility {
     return Compatibility.is(...ALL_VERSIONS_IN_ORDER.slice(index));
   }
 
-  static isLessThan(version: GpVersion) {
-    return !Compatibility.isGreaterOrEqual(version);
-  }
-
   /**
    * Allows selecting different values for different Gray Paper versions from one record.
    *

--- a/packages/jam/state-json/accounts.ts
+++ b/packages/jam/state-json/accounts.ts
@@ -138,18 +138,18 @@ export class JsonService {
   static fromJson = json.object<JsonService, InMemoryService>(
     {
       id: "number",
-      data: Compatibility.isLessThan(GpVersion.V0_7_1)
+      data: Compatibility.isGreaterOrEqual(GpVersion.V0_7_1)
         ? {
-            service: JsonServiceInfo.fromJson,
-            preimages: json.optional(json.array(JsonPreimageItem.fromJson)),
-            storage: json.optional(json.array(JsonStorageItem.fromJson)),
-            lookup_meta: json.optional(json.array(lookupMetaFromJson)),
-          }
-        : {
             service: JsonServiceInfo.fromJson,
             storage: json.optional(json.array(JsonStorageItem.fromJson)),
             preimages_blob: json.optional(json.array(JsonPreimageItem.fromJson)),
             preimages_status: json.optional(json.array(preimageStatusFromJson)),
+          }
+        : {
+            service: JsonServiceInfo.fromJson,
+            preimages: json.optional(json.array(JsonPreimageItem.fromJson)),
+            storage: json.optional(json.array(JsonStorageItem.fromJson)),
+            lookup_meta: json.optional(json.array(lookupMetaFromJson)),
           },
     },
     ({ id, data }) => {

--- a/packages/jam/state-json/statistics.ts
+++ b/packages/jam/state-json/statistics.ts
@@ -84,12 +84,12 @@ class JsonServiceStatistics {
       extrinsic_count: "number",
       accumulate_count: "number",
       accumulate_gas_used: json.fromBigInt(tryAsServiceGas),
-      ...(Compatibility.isLessThan(GpVersion.V0_7_1)
-        ? {
+      ...(Compatibility.isGreaterOrEqual(GpVersion.V0_7_1)
+        ? {}
+        : {
             on_transfers_count: "number",
             on_transfers_gas_used: json.fromBigInt(tryAsServiceGas),
-          }
-        : {}),
+          }),
     },
     ({
       provided_count,

--- a/packages/jam/transition/accumulate/accumulate.ts
+++ b/packages/jam/transition/accumulate/accumulate.ts
@@ -441,7 +441,7 @@ export class Accumulate {
        *
        * https://graypaper.fluffylabs.dev/#/1c979cb/18ae0318ae03?v=0.7.1
        */
-      const shouldUpdateStatisticsPre072 = Compatibility.isLessThan(GpVersion.V0_7_2) && count > 0;
+      const shouldUpdateStatisticsPre072 = !Compatibility.isGreaterOrEqual(GpVersion.V0_7_2) && count > 0;
       /**
        * [0.7.2]: We update statistics if anything is changed
        *

--- a/packages/jam/transition/chain-stf.ts
+++ b/packages/jam/transition/chain-stf.ts
@@ -338,7 +338,7 @@ export class OnChain {
     let transferStatistics = new Map<ServiceId, CountAndGasUsed>();
     let servicesUpdate: ServicesUpdate = { ...servicesUpdateFromAccumulate, preimages: accumulatePreimages };
 
-    if (Compatibility.isLessThan(GpVersion.V0_7_1)) {
+    if (!Compatibility.isGreaterOrEqual(GpVersion.V0_7_1)) {
       const deferredTransfersResult = await this.deferredTransfers.transition({
         entropy: entropy[0],
         pendingTransfers,

--- a/packages/jam/transition/externalities/accumulate-externalities.ts
+++ b/packages/jam/transition/externalities/accumulate-externalities.ts
@@ -576,7 +576,7 @@ export class AccumulateExternalities
     registrar: ServiceId | null,
     autoAccumulateServices: Map<ServiceId, ServiceGas>,
   ): Result<OK, UpdatePrivilegesError> {
-    if (Compatibility.isLessThan(GpVersion.V0_7_1)) {
+    if (!Compatibility.isGreaterOrEqual(GpVersion.V0_7_1)) {
       /** https://graypaper.fluffylabs.dev/#/7e6ff6a/36d90036de00?v=0.6.7 */
       const current = this.updatedState.getPrivilegedServices();
       const isManager = current.manager === this.currentServiceId;


### PR DESCRIPTION
Having two possible ways for triggering compatibility is pretty confusing and creates increased mental workload. This PR removes IMHO less easy to parse method: isLessThan. I chose to remove this one, because it's exclusive so it requires an extra cognitive effort to figure out the previous version as the last applicable for the if statement.
