### PR TITLE
Update links in reports

### DIFF
--- a/packages/jam/block-json/work-result.ts
+++ b/packages/jam/block-json/work-result.ts
@@ -18,7 +18,7 @@ const workExecResultFromJson = json.object<JsonWorkExecResult, WorkExecResult>(
     output_oversize: json.optional(json.fromAny(() => null)),
   },
   (val) => {
-    const { ok, out_of_gas, panic, bad_code, code_oversize } = val;
+    const { ok, out_of_gas, panic, bad_code, code_oversize, output_oversize } = val;
     if (ok !== undefined) {
       return new WorkExecResult(tryAsU32(WorkExecResultKind.ok), ok);
     }
@@ -34,7 +34,7 @@ const workExecResultFromJson = json.object<JsonWorkExecResult, WorkExecResult>(
     if (code_oversize === null) {
       return new WorkExecResult(tryAsU32(WorkExecResultKind.codeOversize));
     }
-    if (val.output_oversize === null) {
+    if (output_oversize === null) {
       return new WorkExecResult(tryAsU32(WorkExecResultKind.digestTooBig));
     }
 

--- a/packages/jam/block/gp-constants.ts
+++ b/packages/jam/block/gp-constants.ts
@@ -44,9 +44,6 @@ export const W_C = 4_000_000;
 /** `W_M`: The maximum number of imports in a work-package. */
 export const W_M = 3_072;
 
-/** `W_R`: The maximum total size of all output blobs in a work-report, in octets. */
-export const W_R = 49_152;
-
 /** `W_T`: The size of a transfer memo in octets. */
 export const W_T = 128;
 

--- a/packages/jam/block/guarantees.ts
+++ b/packages/jam/block/guarantees.ts
@@ -14,7 +14,7 @@ import { WorkReport } from "./work-report.js";
  * Since GP defines that value explicitly as "two or three",
  * we do that as well.
  *
- * https://graypaper.fluffylabs.dev/#/579bd12/14b90214bb02
+ * https://graypaper.fluffylabs.dev/#/ab2cdbd/152b01152d01?v=0.7.2
  */
 export type REQUIRED_CREDENTIALS = 2 | 3;
 export const REQUIRED_CREDENTIALS_RANGE = [2, 3];
@@ -43,7 +43,7 @@ export class Credential extends WithDebug {
 /**
  * Tuple of work-report, a credential and it's corresponding timeslot.
  *
- * https://graypaper.fluffylabs.dev/#/579bd12/147102149102
+ * https://graypaper.fluffylabs.dev/#/ab2cdbd/15df00150301?v=0.7.2
  */
 export class ReportGuarantee extends WithDebug {
   static Codec = codec.Class(ReportGuarantee, {
@@ -70,7 +70,7 @@ export class ReportGuarantee extends WithDebug {
      * validator index and a signature.
      * Credentials must be ordered by their validator index.
      *
-     * https://graypaper.fluffylabs.dev/#/579bd12/14b90214bb02
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/152b01152d01?v=0.7.2
      */
     public readonly credentials: KnownSizeArray<Credential, `${REQUIRED_CREDENTIALS}`>,
   ) {
@@ -85,7 +85,7 @@ export const GuaranteesExtrinsicBounds = "[0..CoresCount)";
  * Each core index (within work-report) must be unique and guarantees
  * must be in ascending order of this.
  *
- * https://graypaper.fluffylabs.dev/#/579bd12/146402146702
+ * https://graypaper.fluffylabs.dev/#/ab2cdbd/15d10015d400?v=0.7.2
  */
 export type GuaranteesExtrinsic = KnownSizeArray<ReportGuarantee, typeof GuaranteesExtrinsicBounds>;
 

--- a/packages/jam/transition/externalities/fetch-externalities.ts
+++ b/packages/jam/transition/externalities/fetch-externalities.ts
@@ -1,18 +1,5 @@
 import type { EntropyHash } from "@typeberry/block";
-import {
-  G_I,
-  MAX_REPORT_DEPENDENCIES,
-  O,
-  Q,
-  T,
-  W_A,
-  W_B,
-  W_C,
-  W_M,
-  W_R,
-  W_T,
-  W_X,
-} from "@typeberry/block/gp-constants.js";
+import { G_I, MAX_REPORT_DEPENDENCIES, O, Q, T, W_A, W_B, W_C, W_M, W_T, W_X } from "@typeberry/block/gp-constants.js";
 import { MAX_NUMBER_OF_WORK_ITEMS } from "@typeberry/block/work-package.js";
 import type { BytesBlob } from "@typeberry/bytes";
 import { codec, Encoder } from "@typeberry/codec";
@@ -28,6 +15,7 @@ import {
 import { GAS_TO_INVOKE_WORK_REPORT } from "../accumulate/accumulate-state.js";
 import { Operand } from "../accumulate/operand.js";
 import { REPORT_TIMEOUT_GRACE_PERIOD } from "../assurances.js";
+import { MAX_WORK_REPORT_SIZE_BYTES } from "../reports/verify-basic.js";
 
 enum TransferOperandKind {
   OPERAND = 0,
@@ -164,7 +152,7 @@ function getEncodedConstants(chainSpec: ChainSpec) {
     W_E: tryAsU32(chainSpec.erasureCodedPieceSize),
     W_M: tryAsU32(W_M),
     W_P: tryAsU32(chainSpec.numberECPiecesPerSegment),
-    W_R: tryAsU32(W_R),
+    W_R: tryAsU32(MAX_WORK_REPORT_SIZE_BYTES),
     W_T: tryAsU32(W_T),
     W_X: tryAsU32(W_X),
     Y: tryAsU32(chainSpec.contestLength),

--- a/packages/jam/transition/reports/guarantor-assignment.ts
+++ b/packages/jam/transition/reports/guarantor-assignment.ts
@@ -4,9 +4,9 @@
  * reports for it. This is borne out with V= 1023 validators
  * and C = 341 cores, since V/C = 3. The core index assigned to
  * each of the validators, as well as the validators’ Ed25519
- * keys are denoted by G.
+ * keys are denoted by M.
  *
- * https://graypaper.fluffylabs.dev/#/5f542d7/147601147e01
+ * https://graypaper.fluffylabs.dev/#/ab2cdbd/144c02145402?v=0.7.2
  */
 
 import {
@@ -29,12 +29,12 @@ export type RotationIndex = Opaque<number, "RotationIndex">;
 /**
  * Returns core assignments for each validator index.
  *
- * https://graypaper.fluffylabs.dev/#/5f542d7/14fd0114fd01
+ * https://graypaper.fluffylabs.dev/#/ab2cdbd/155300155d00?v=0.7.2
  */
 export function generateCoreAssignment(
   spec: ChainSpec,
   blake2b: Blake2b,
-  /** https://graypaper.fluffylabs.dev/#/5f542d7/149601149601 */
+  /** https://graypaper.fluffylabs.dev/#/ab2cdbd/147102147102?v=0.7.2 */
   eta2entropy: EntropyHash,
   /** timeslot */
   slot: TimeSlot,
@@ -47,7 +47,7 @@ export function rotationIndex(slot: TimeSlot, rotationPeriod: number): RotationI
   return asOpaqueType(Math.floor(slot / rotationPeriod));
 }
 
-/** https://graypaper.fluffylabs.dev/#/5f542d7/14c00114c001 */
+/** https://graypaper.fluffylabs.dev/#/ab2cdbd/151900151900?v=0.7.2 */
 function permute(
   blake2b: Blake2b,
   entropy: EntropyHash,
@@ -69,7 +69,7 @@ function permute(
   return asKnownSize(coreAssignment);
 }
 
-/** https://graypaper.fluffylabs.dev/#/5f542d7/14a50114a501 */
+/** https://graypaper.fluffylabs.dev/#/ab2cdbd/148002148002?v=0.7.2 */
 function rotate(cores: CoreIndex[], n: number, noOfCores: number) {
   // modulo `noOfCores` guarantees that we're within `CoreIndex` range.
   return cores.map((x) => asOpaqueType((x + n) % noOfCores));

--- a/packages/jam/transition/reports/input.ts
+++ b/packages/jam/transition/reports/input.ts
@@ -18,38 +18,43 @@ export interface HeaderChain {
  * by validators).
  *
  * After enough assurances the work-report is considered available,
- * and the work outputs transform the state of their associated
+ * and the work-digests transform the state of their associated
  * service by virtue of accumulation, covered in section 12.
  * The report may also be timed-out, implying it may be replaced
  * by another report without accumulation.
  *
- * https://graypaper.fluffylabs.dev/#/5f542d7/133d00134200
+ * https://graypaper.fluffylabs.dev/#/ab2cdbd/138801138d01?v=0.7.2
  */
 export type ReportsInput = {
   /**
    * A work-package, is transformed by validators acting as
    * guarantors into its corresponding work-report, which
-   * similarly comprises several work outputs and then
+   * similarly comprises several work-digests and then
    * presented on-chain within the guarantees extrinsic.
    *
-   * https://graypaper.fluffylabs.dev/#/5f542d7/133500133900
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/138001138401?v=0.7.2
    */
   guarantees: GuaranteesExtrinsicView;
   /** Current time slot, excerpted from block header. */
   slot: TimeSlot;
   /** `eta_prime`: New entropy, after potential epoch transition. */
   newEntropy: SafroleStateUpdate["entropy"];
-  /** Partial update of recent blocks. (β†, https://graypaper.fluffylabs.dev/#/9a08063/0fd8010fdb01?v=0.6.6) */
+  /**
+   * β† - Partial update of recent blocks.
+   *
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/0f56020f6b02?v=0.7.2
+   */
   recentBlocksPartialUpdate: RecentHistoryStateUpdate["recentBlocks"];
   /**
    * ρ‡ - Availability assignment resulting from assurances transition
-   * https://graypaper.fluffylabs.dev/#/1c979cb/141302144402?v=0.7.1
+   *
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/141302144402?v=0.7.2
    */
   assurancesAvailAssignment: AssurancesStateUpdate["availabilityAssignment"];
   /**
    * ψ′O - Ed25519 keys of validators that were proven to judge incorrectly.
    *
-   * https://graypaper.fluffylabs.dev/#/1c979cb/134201134201?v=0.7.1
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/134201134201?v=0.7.2
    */
   offenders: HashSet<Ed25519Key>;
 };

--- a/packages/jam/transition/reports/reports.ts
+++ b/packages/jam/transition/reports/reports.ts
@@ -49,7 +49,7 @@ export type ReportsOutput = {
    * This dictionary has the same number of items as in the input guarantees extrinsic.
    */
   reported: HashDictionary<WorkPackageHash, WorkPackageInfo>;
-  /** A set `R` of work package reporters. */
+  /** A set `M` of work package reporters. */
   reporters: KnownSizeArray<Ed25519Key, "Guarantees * Credentials (at most `cores*3`)">;
 };
 
@@ -109,10 +109,11 @@ export class Reports {
     /**
      * ρ′ - equivalent to ρ‡, except where the extrinsic replaced
      * an entry. In the case an entry is replaced, the new value
-     * includes the present time τ ′ allowing for the value to be
+     * includes the present time τ' allowing for the value to be
      * replaced without respect to its availability once sufficient
      * time has elapsed.
-     * https://graypaper.fluffylabs.dev/#/1c979cb/161e00165900?v=0.7.1
+     *
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/161e00165900?v=0.7.2
      */
     const availabilityAssignment = input.assurancesAvailAssignment.slice();
 
@@ -198,7 +199,7 @@ export class Reports {
    * Get the guarantor assignment (both core and validator data)
    * depending on the rotation.
    *
-   * https://graypaper.fluffylabs.dev/#/5f542d7/158200158200
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/15df0115df01?v=0.7.2
    */
   getGuarantorAssignment(
     headerTimeSlot: TimeSlot,
@@ -211,7 +212,7 @@ export class Reports {
     const guaranteeRotation = rotationIndex(guaranteeTimeSlot, rotationPeriod);
     const minTimeSlot = Math.max(0, headerRotation - 1) * rotationPeriod;
 
-    // https://graypaper.fluffylabs.dev/#/5f542d7/155e00156900
+    // https://graypaper.fluffylabs.dev/#/ab2cdbd/15980115be01?v=0.7.2
     if (guaranteeTimeSlot > headerTimeSlot) {
       return Result.error(
         ReportsError.FutureReportSlot,
@@ -227,7 +228,7 @@ export class Reports {
     }
 
     // TODO [ToDr] [opti] below code needs cache.
-    // The `G` and `G*` sets should only be computed once per rotation.
+    // The `M` and `M*` sets should only be computed once per rotation.
 
     // Default data for the current rotation
     let entropy = newEntropy[2];
@@ -248,7 +249,7 @@ export class Reports {
     }
 
     // we know which entropy, timeSlot and validatorData should be used,
-    // so we can compute `G` or `G*` here.
+    // so we can compute `M` or `M*` here.
     const coreAssignment = generateCoreAssignment(this.chainSpec, this.blake2b, entropy, timeSlot);
     return Result.ok(
       zip(coreAssignment, validatorData, (core, validator) => ({

--- a/packages/jam/transition/reports/verify-basic.ts
+++ b/packages/jam/transition/reports/verify-basic.ts
@@ -18,7 +18,7 @@ export function verifyReportsBasic(input: GuaranteesExtrinsicView): Result<OK, R
      * segment-root lookup dictionary and the number of
      * prerequisites to J = 8:
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/13ab0013ad00?v=0.6.2
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/13fd0113ff01?v=0.7.2
      */
     const noOfPrerequisites = reportView.context.view().prerequisites.view().length;
     const noOfSegmentRootLookups = reportView.segmentRootLookup.view().length;
@@ -36,7 +36,7 @@ export function verifyReportsBasic(input: GuaranteesExtrinsicView): Result<OK, R
      * successful output blobs together with the authorizer output
      * blob, effectively limiting their overall size:
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/141d00142000?v=0.6.2
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/14a80014ab00?v=0.7.2
      */
     // adding is safe here, since the total-encoded size of the report
     // is limited as well. Even though we just have a view, the size

--- a/packages/jam/transition/reports/verify-contextual.ts
+++ b/packages/jam/transition/reports/verify-contextual.ts
@@ -18,7 +18,7 @@ import type { HeaderChain, ReportsInput } from "./input.js";
 
 const logger = Logger.new(import.meta.filename, "stf:reports");
 
-/** https://graypaper.fluffylabs.dev/#/7e6ff6a/15eb0115eb01?v=0.6.7 */
+/** https://graypaper.fluffylabs.dev/#/ab2cdbd/158202158202?v=0.7.2 */
 export function verifyContextualValidity(
   input: ReportsInput,
   state: Pick<
@@ -51,8 +51,11 @@ export function verifyContextualValidity(
         return Result.error(ReportsError.BadServiceId, () => `No service with id: ${result.serviceId}`);
       }
 
-      // check service code hash
-      // https://graypaper.fluffylabs.dev/#/5f542d7/154b02154b02
+      /**
+       * Check service code hash
+       *
+       * https://graypaper.fluffylabs.dev/#/ab2cdbd/150804150804?v=0.7.2
+       */
       if (!result.codeHash.isEqualTo(service.getInfo().codeHash)) {
         return Result.error(
           ReportsError.BadCodeHash,
@@ -67,7 +70,7 @@ export function verifyContextualValidity(
    * There must be no duplicate work-package hashes (i.e.
    * two work-reports of the same package).
    *
-   * https://graypaper.fluffylabs.dev/#/5f542d7/151f01152101
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/159c02159e02?v=0.7.2
    */
   if (currentWorkPackages.size !== input.guarantees.length) {
     return Result.error(ReportsError.DuplicatePackage, () => "Duplicate work package detected.");
@@ -132,7 +135,7 @@ export function verifyContextualValidity(
   return Result.ok(currentWorkPackages);
 }
 
-/** https://graypaper.fluffylabs.dev/#/7e6ff6a/152502152502?v=0.6.7 */
+/** https://graypaper.fluffylabs.dev/#/ab2cdbd/15cd0215cd02?v=0.7.2 */
 function verifyRefineContexts(
   minLookupSlot: number,
   contexts: RefineContext[],
@@ -149,9 +152,9 @@ function verifyRefineContexts(
     /**
      * We require that the anchor block be within the last H
      * blocks and that its details be correct by ensuring that it
-     * appears within our most recent blocks β †:
+     * appears within our most recent blocks β†:
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/152801152b01
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/15ad0215af02?v=0.7.2
      */
     const recentBlock = recentBlocks.get(context.anchor);
     if (recentBlock === undefined) {
@@ -183,7 +186,7 @@ function verifyRefineContexts(
      * We require that each lookup-anchor block be within the
      * last L timeslots.
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/154601154701
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/15ce0215cf02?v=0.7.2
      */
     if (context.lookupAnchorSlot < minLookupSlot) {
       return Result.error(
@@ -198,7 +201,7 @@ function verifyRefineContexts(
      * on-chain state and must be checked by virtue of retaini
      * ing the series of the last L headers as the ancestor set A.
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/155c01155f01
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/15e40215e702?v=0.7.2
      */
     const isInChain =
       recentBlocks.has(context.lookupAnchor) ||
@@ -240,7 +243,7 @@ function verifyDependencies({
      * segment-root lookup, be either in the extrinsic or in our
      * recent history.
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/15ca0115cd01
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/156b03156e03?v=0.7.2
      */
     for (const preReqHash of dependencies) {
       if (currentWorkPackages.has(preReqHash)) {
@@ -281,7 +284,7 @@ function verifyWorkPackagesUniqueness(
   /**
    * Make sure that the package does not appear anywhere in the pipeline.
    *
-   * https://graypaper.fluffylabs.dev/#/5f542d7/159101159101
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/152803152803?v=0.7.2
    */
   // TODO [ToDr] [opti] this most likely should be cached and either
   // re-computed on invalidity or we could maintain additional

--- a/packages/jam/transition/reports/verify-credentials.ts
+++ b/packages/jam/transition/reports/verify-credentials.ts
@@ -28,9 +28,9 @@ export function verifyCredentials(
 ): Result<ed25519.Input[], ReportsError> {
   /**
    * Collect signatures payload for later verification
-   * and construct the `reporters set R` from that data.
+   * and construct the `reporters set G` from that data.
    *
-   * https://graypaper.fluffylabs.dev/#/5f542d7/15cf0015cf00
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/153002153002?v=0.7.2
    */
   const signaturesToVerify: ed25519.Input[] = [];
   const headerTimeSlot = slot;
@@ -44,7 +44,7 @@ export function verifyCredentials(
      * The credential is a sequence of two or three tuples of a
      * unique validator index and a signature.
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/14b90214bb02
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/152b01152d01?v=0.7.2
      */
     const credentialsView = guaranteeView.credentials.view();
     if (
@@ -89,7 +89,8 @@ export function verifyCredentials(
 
       /**
        * Verify core assignment.
-       * https://graypaper.fluffylabs.dev/#/5f542d7/14e40214e602
+       *
+       * https://graypaper.fluffylabs.dev/#/ab2cdbd/155201155401?v=0.7.2
        */
       if (guarantorData.core !== coreIndex) {
         return Result.error(
@@ -116,7 +117,7 @@ const JAM_GUARANTEE = BytesBlob.blobFromString("jam_guarantee").raw;
  * The signature [...] whose message is the serialization of the hash
  * of the work-report.
  *
- * https://graypaper.fluffylabs.dev/#/5f542d7/155200155200
+ * https://graypaper.fluffylabs.dev/#/ab2cdbd/15a20115a201?v=0.7.2
  */
 function signingPayload(hash: WorkReportHash) {
   return BytesBlob.blobFromParts(JAM_GUARANTEE, hash.raw);

--- a/packages/jam/transition/reports/verify-order.ts
+++ b/packages/jam/transition/reports/verify-order.ts
@@ -8,7 +8,7 @@ export function verifyReportsOrder(input: GuaranteesExtrinsicView, chainSpec: Ch
    * The core index of each guarantee must be unique and
    * guarantees must be in ascending order of this.
    *
-   * https://graypaper.fluffylabs.dev/#/5f542d7/146902146a02
+   * https://graypaper.fluffylabs.dev/#/ab2cdbd/15d60015d700?v=0.7.2
    */
   const noOfCores = chainSpec.coresCount;
   let lastCoreIndex = -1;

--- a/packages/jam/transition/reports/verify-post-signature.ts
+++ b/packages/jam/transition/reports/verify-post-signature.ts
@@ -21,7 +21,7 @@ export function verifyPostSignatureChecks(
      * No reports may be placed on cores with a report pending
      * availability on it.
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/15ea0015ea00
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/155002155002?v=0.7.2
      */
     if (availabilityAssignment[coreIndex] !== null) {
       return Result.error(ReportsError.CoreEngaged, () => `Report pending availability at core: ${coreIndex}`);
@@ -32,7 +32,7 @@ export function verifyPostSignatureChecks(
      * in the authorizer pool of the core on which the work is
      * reported.
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/15eb0015ed00
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/155102155302?v=0.7.2
      */
     const authorizerHash = report.authorizerHash;
     const authorizerPool = authPools.get(coreIndex);
@@ -46,10 +46,10 @@ export function verifyPostSignatureChecks(
 
     /**
      * We require that the gas allotted for accumulation of each
-     * work item in each work-report respects its service’s
+     * work-digest in each work-report respects its service’s
      * minimum gas requirements.
      *
-     * https://graypaper.fluffylabs.dev/#/5f542d7/15f80015fa00
+     * https://graypaper.fluffylabs.dev/#/ab2cdbd/156602156802?v=0.7.2
      */
     for (const result of report.results) {
       const service = services(result.serviceId);

--- a/packages/jam/transition/statistics.test.ts
+++ b/packages/jam/transition/statistics.test.ts
@@ -11,7 +11,7 @@ import {
   tryAsValidatorIndex,
 } from "@typeberry/block";
 import { type AssurancesExtrinsic, AvailabilityAssurance } from "@typeberry/block/assurances.js";
-import { I, T, W_M, W_R, W_X } from "@typeberry/block/gp-constants.js";
+import { I, T, W_M, W_X } from "@typeberry/block/gp-constants.js";
 import type { GuaranteesExtrinsic } from "@typeberry/block/guarantees.js";
 import type { PreimagesExtrinsic } from "@typeberry/block/preimage.js";
 import { testWorkReportHex } from "@typeberry/block/test-helpers.js";
@@ -41,6 +41,7 @@ import {
   ValidatorStatistics,
 } from "@typeberry/state";
 import { asOpaqueType } from "@typeberry/utils";
+import { MAX_WORK_REPORT_SIZE_BYTES } from "./reports/verify-basic.js";
 import { Statistics, type StatisticsState } from "./statistics.js";
 import { copyAndUpdateState } from "./test.utils.js";
 
@@ -59,11 +60,11 @@ describe("Statistics", () => {
     });
 
     it("max extrinsic size score formula should fit into U32", () => {
-      assert.strictEqual(isU32(W_R * I), true);
+      assert.strictEqual(isU32(MAX_WORK_REPORT_SIZE_BYTES * I), true);
     });
 
     it("max data availability score formula should fit into U32", () => {
-      assert.strictEqual(isU32(W_R + EC_SEGMENT_SIZE * ((W_M * 65) / 64)), true);
+      assert.strictEqual(isU32(MAX_WORK_REPORT_SIZE_BYTES + EC_SEGMENT_SIZE * ((W_M * 65) / 64)), true);
     });
   });
 


### PR DESCRIPTION
### Changes:
- updated all links to GP 0.7.2
- adjusted names/symbols (i.e. `G` => `M`, work outout => work digest)
- removed `W_R` from GP consts (we had this const in two places)
- small code style adjustment (block-json/work-result.ts)
