### PR TITLE
Add initGenesisFromAncestry mode to fuzz target

### DIFF
--- a/bin/jam/args.ts
+++ b/bin/jam/args.ts
@@ -59,7 +59,7 @@ export type Arguments =
       SharedOptions & {
         socket: string | null;
         version: 1;
-        noVerify: boolean;
+        initGenesisFromAncestry: boolean;
       }
     >
   | CommandArgs<
@@ -147,11 +147,10 @@ export function parseArgs(input: string[], withRelPath: (v: string) => string): 
     case Command.FuzzTarget: {
       const data = parseSharedOptions(args);
       const { version } = parseValueOption(args, "version", "number", parseFuzzVersion, 1);
-      // minimist parses --no-X as { X: false }
-      const noVerify = args.verify === false;
-      delete args.verify;
-      if (noVerify) {
-        logger.warn`Verification mode is disabled for the fuzz target. This is unsafe and should only be used for debugging.`;
+      const initGenesisFromAncestry = args["init-genesis-from-ancestry"] === true;
+      delete args["init-genesis-from-ancestry"];
+      if (initGenesisFromAncestry) {
+        logger.warn`Init genesis from ancestry is enabled. Parent hash and state root verification is skipped.`;
       }
       const socket = args._.shift() ?? null;
       assertNoMoreArgs(args);
@@ -161,7 +160,7 @@ export function parseArgs(input: string[], withRelPath: (v: string) => string): 
           ...data,
           version,
           socket,
-          noVerify,
+          initGenesisFromAncestry,
         },
       };
     }

--- a/bin/jam/index.ts
+++ b/bin/jam/index.ts
@@ -106,8 +106,8 @@ async function startNode(args: Arguments, withRelPath: (p: string) => string) {
   if (args.command === Command.FuzzTarget) {
     const version = args.args.version;
     const socket = args.args.socket;
-    const noVerify = args.args.noVerify;
-    return mainFuzz({ jamNodeConfig, version, socket, noVerify }, withRelPath);
+    const initGenesisFromAncestry = args.args.initGenesisFromAncestry;
+    return mainFuzz({ jamNodeConfig, version, socket, initGenesisFromAncestry }, withRelPath);
   }
 
   // Just import a bunch of blocks

--- a/packages/jam/node/common.ts
+++ b/packages/jam/node/common.ts
@@ -53,7 +53,7 @@ export function getDatabasePath(
  * The function checks the genesis header
  */
 export type InitDbOptions = {
-  noVerify?: boolean;
+  initGenesisFromAncestry?: boolean;
 };
 
 export async function initializeDatabase(
@@ -92,8 +92,9 @@ export async function initializeDatabase(
   const { genesisStateSerialized, genesisStateRootHash } = loadGenesisState(spec, blake2b, config.genesisState);
 
   // write to db
-  // When noVerify is set, use ancestry[0][0] as the initial block hash (for fuzz-target mode)
-  const initialBlockHash = (options.noVerify ?? false) && ancestry.length > 0 ? ancestry[0][0] : genesisHeaderHash;
+  // When initGenesisFromAncestry is set, use ancestry[0][0] as the initial block hash (for fuzz-target mode)
+  const initialBlockHash =
+    (options.initGenesisFromAncestry ?? false) && ancestry.length > 0 ? ancestry[0][0] : genesisHeaderHash;
   await blocks.insertBlock(new WithHash<HeaderHash, BlockView>(initialBlockHash, blockView));
   // insert fake blocks for ancestry data
   for (const [hash, slot] of ancestry) {

--- a/packages/jam/node/main-fuzz.ts
+++ b/packages/jam/node/main-fuzz.ts
@@ -18,7 +18,7 @@ export type FuzzConfig = {
   version: FuzzVersion;
   jamNodeConfig: JamConfig;
   socket: string | null;
-  noVerify: boolean;
+  initGenesisFromAncestry: boolean;
 };
 
 const logger = Logger.new(import.meta.filename, "fuzztarget");
@@ -91,7 +91,7 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
           network: null,
         },
         withRelPath,
-        { noVerify: fuzzConfig.noVerify },
+        { initGenesisFromAncestry: fuzzConfig.initGenesisFromAncestry },
       );
       runningNode = newNode;
       return await newNode.getBestStateRootHash();

--- a/packages/jam/node/main-importer.ts
+++ b/packages/jam/node/main-importer.ts
@@ -14,7 +14,7 @@ import packageJson from "./package.json" with { type: "json" };
 const zeroHash = Bytes.zero(HASH_SIZE).asOpaque<StateRootHash>();
 
 export type ImporterOptions = {
-  noVerify?: boolean;
+  initGenesisFromAncestry?: boolean;
 };
 
 export async function mainImporter(
@@ -62,11 +62,13 @@ export async function mainImporter(
   logger.info`🛢️ Opening database at ${dbPath}`;
   const rootDb = workerConfig.openDatabase({ readonly: false });
   await initializeDatabase(chainSpec, blake2b, genesisHeaderHash, rootDb, config.node.chainSpec, config.ancestry, {
-    noVerify: options.noVerify,
+    initGenesisFromAncestry: options.initGenesisFromAncestry,
   });
   await rootDb.close();
 
-  const { db, importer } = await createImporter(workerConfig, { noVerify: options.noVerify });
+  const { db, importer } = await createImporter(workerConfig, {
+    initGenesisFromAncestry: options.initGenesisFromAncestry,
+  });
   await importer.prepareForNextEpoch();
 
   const api: NodeApi = {

--- a/packages/workers/importer/importer.ts
+++ b/packages/workers/importer/importer.ts
@@ -27,7 +27,7 @@ const importerError = <Kind extends ImporterErrorKind, Err extends ImporterError
 ) => Result.taggedError<WithHash<HeaderHash, HeaderView>, Kind, Err>(ImporterErrorKind, kind, nested);
 
 export type ImporterOptions = {
-  noVerify?: boolean;
+  initGenesisFromAncestry?: boolean;
 };
 
 export class Importer {
@@ -116,7 +116,7 @@ export class Importer {
     const timerVerify = measure("import:verify");
     const verifyStart = now();
     const hash = await this.verifier.verifyBlock(block, {
-      skipParentAndStateRoot: this.options.noVerify ?? false,
+      skipParentAndStateRoot: this.options.initGenesisFromAncestry ?? false,
     });
     const verifyDuration = now() - verifyStart;
     logger.log`${timerVerify()}`;

--- a/packages/workers/importer/main.ts
+++ b/packages/workers/importer/main.ts
@@ -16,7 +16,7 @@ const blake2b = Blake2b.createHasher();
 export type Config = WorkerConfig<ImporterConfig, BlocksDb, StatesDb<SerializedState<LeafDb>>>;
 
 export type CreateImporterOptions = {
-  noVerify?: boolean;
+  initGenesisFromAncestry?: boolean;
 };
 
 export async function createImporter(


### PR DESCRIPTION
I added `--init-genesis-from-ancestry` mode to accept traces converted into fuzz messages from this repo: https://github.com/FluffyLabs/picofuzz-conformance-data
