### PR TITLE
Disable GHA cache for test vectors

### DIFF
--- a/.github/workflows/vectors-test-suites.yml
+++ b/.github/workflows/vectors-test-suites.yml
@@ -23,24 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - display_name: conformance-0.7.0
-            gp_version: 0.7.0
-            script: jam-conformance-070.ts
-            output: jam-conformance-070.txt
-            artifact_name: conformance-070-results
-            submodule: jam-conformance_070
-          - display_name: conformance-0.7.1
-            gp_version: 0.7.1
-            script: jam-conformance-071.ts
-            output: jam-conformance-071.txt
-            artifact_name: conformance-071-results
-            submodule: jam-conformance_071
           - display_name: conformance-0.7.2
             gp_version: 0.7.2
             script: jam-conformance-072.ts
             output: jam-conformance-072.txt
             artifact_name: conformance-072-results
-            submodule: jam-conformance_072
+            submodule: jam-conformance
           - display_name: w3f-0.7.0
             gp_version: 0.7.0
             script: w3f-070.ts


### PR DESCRIPTION
It seems that caching the submodules is much slower than simply checking them out. Additionally this PR introduces selective checkout which should be even faster.
