### PR TITLE
Bump anan-as to the newest version

### DIFF
--- a/bin/lib/package.json
+++ b/bin/lib/package.json
@@ -39,10 +39,8 @@
     "./workers-api": "./exports/workers-api.js"
   },
   "dependencies": {
-    "@fluffylabs/anan-as": "^1.1.3",
+    "@fluffylabs/anan-as": "^1.1.5",
     "@noble/ed25519": "2.2.3",
-    "@typeberry/native": "0.0.4-4c0cd28",
-    "hash-wasm": "4.12.0",
     "@typeberry/block": "*",
     "@typeberry/block-json": "*",
     "@typeberry/bytes": "*",
@@ -60,6 +58,7 @@
     "@typeberry/json-parser": "*",
     "@typeberry/logger": "*",
     "@typeberry/mmr": "*",
+    "@typeberry/native": "0.0.4-4c0cd28",
     "@typeberry/numbers": "*",
     "@typeberry/ordering": "*",
     "@typeberry/pvm-host-calls": "*",
@@ -73,7 +72,8 @@
     "@typeberry/transition": "*",
     "@typeberry/trie": "*",
     "@typeberry/utils": "*",
-    "@typeberry/workers-api": "*"
+    "@typeberry/workers-api": "*",
+    "hash-wasm": "4.12.0"
   },
   "scripts": {
     "docs": "npm run docs:examples",

--- a/package-lock.json
+++ b/package-lock.json
@@ -205,7 +205,7 @@
       "version": "0.5.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@fluffylabs/anan-as": "^1.1.3",
+        "@fluffylabs/anan-as": "^1.1.5",
         "@noble/ed25519": "2.2.3",
         "@typeberry/block": "*",
         "@typeberry/block-json": "*",
@@ -1185,14 +1185,10 @@
       }
     },
     "node_modules/@fluffylabs/anan-as": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@fluffylabs/anan-as/-/anan-as-1.1.3.tgz",
-      "integrity": "sha512-/EE8fRqL1i/f63DKO7gSTqLy9OpVoQf1bknT7MsQDB77uyKSwhtEF8Q7mIp8TDKwxUJXpQ1V3iWHHfLMo9R5ag==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@typeberry/lib": "^0.2.0",
-        "json-bigint-patch": "^0.0.8"
-      }
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@fluffylabs/anan-as/-/anan-as-1.1.5.tgz",
+      "integrity": "sha512-TRCCd5npU38ozMBPPj/0wzCrZ+brsnXL9oZQ1lC38s6OnBeg8cznLMaMNU3GCpR2FpU52dusq7ZgNeoUcAmoSQ==",
+      "license": "MPL-2.0"
     },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.15.0",
@@ -8883,7 +8879,7 @@
       "version": "0.5.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@fluffylabs/anan-as": "^1.1.3",
+        "@fluffylabs/anan-as": "^1.1.5",
         "@typeberry/codec": "*",
         "@typeberry/numbers": "*",
         "@typeberry/pvm-interface": "*",

--- a/packages/core/pvm-interpreter-ananas/package.json
+++ b/packages/core/pvm-interpreter-ananas/package.json
@@ -4,7 +4,7 @@
   "description": "Anan-as PVM implementation.",
   "main": "index.ts",
   "dependencies": {
-    "@fluffylabs/anan-as": "^1.1.3",
+    "@fluffylabs/anan-as": "^1.1.5",
     "@typeberry/codec": "*",
     "@typeberry/numbers": "*",
     "@typeberry/pvm-interface": "*",


### PR DESCRIPTION
It should fix our memory problems (as everything works correctly in case of the built-in intepreter) 