### PR TITLE
Fix assigner change via assign HC

### DIFF
--- a/packages/jam/jam-host-calls/accumulate/bless.ts
+++ b/packages/jam/jam-host-calls/accumulate/bless.ts
@@ -44,8 +44,8 @@ export class Bless implements HostCallHandler {
   async execute(_gas: IGasCounter, regs: HostCallRegisters, memory: HostCallMemory): Promise<undefined | PvmExecution> {
     // `m`: manager service (can change privileged services)
     const manager = getServiceId(regs.get(IN_OUT_REG));
-    // `a`: manages authorization queue
-    const authorization = regs.get(8);
+    // `a`: mem pointer for collection of auth queue assigners (one per core)
+    const assignersPtr = regs.get(8);
     // `v`: manages validator keys
     const delegator = getServiceId(regs.get(9));
     // `r`: manages creation of new services with id within protected range
@@ -79,29 +79,29 @@ export class Bless implements HostCallHandler {
     }
     // https://graypaper.fluffylabs.dev/#/7e6ff6a/367200367200?v=0.6.7
     const res = safeAllocUint8Array(tryAsExactBytes(codec.u32.sizeHint) * this.chainSpec.coresCount);
-    const authorizersDecoder = Decoder.fromBlob(res);
-    const memoryReadResult = memory.loadInto(res, authorization);
+    const assignersDecoder = Decoder.fromBlob(res);
+    const memoryReadResult = memory.loadInto(res, assignersPtr);
     if (memoryReadResult.isError) {
       logger.trace`[${this.currentServiceId}] BLESS(m: ${manager}, v: ${delegator}, r: ${registrar}, ${lazyInspect(autoAccumulate)}) <- PANIC`;
       return PvmExecution.Panic;
     }
 
     // `a`
-    const authorizers = tryAsPerCore(
-      authorizersDecoder.sequenceFixLen(codec.u32.asOpaque<ServiceId>(), this.chainSpec.coresCount),
+    const assigners = tryAsPerCore(
+      assignersDecoder.sequenceFixLen(codec.u32.asOpaque<ServiceId>(), this.chainSpec.coresCount),
       this.chainSpec,
     );
 
     const updateResult = this.partialState.updatePrivilegedServices(
       manager,
-      authorizers,
+      assigners,
       delegator,
       registrar,
       autoAccumulate,
     );
 
     if (updateResult.isOk) {
-      logger.trace`[${this.currentServiceId}] BLESS(m: ${manager}, a: [${authorizers}], v: ${delegator}, r: ${registrar}, ${lazyInspect(autoAccumulate)}) <- OK`;
+      logger.trace`[${this.currentServiceId}] BLESS(m: ${manager}, a: [${assigners}], v: ${delegator}, r: ${registrar}, ${lazyInspect(autoAccumulate)}) <- OK`;
       regs.set(IN_OUT_REG, HostCallResult.OK);
       return;
     }
@@ -110,13 +110,13 @@ export class Bless implements HostCallHandler {
 
     // NOTE: `UpdatePrivilegesError.UnprivilegedService` won't happen in 0.7.1+
     if (e === UpdatePrivilegesError.UnprivilegedService) {
-      logger.trace`[${this.currentServiceId}] BLESS(m: ${manager}, a: [${authorizers}], v: ${delegator}, r: ${registrar}, ${lazyInspect(autoAccumulate)}) <- HUH`;
+      logger.trace`[${this.currentServiceId}] BLESS(m: ${manager}, a: [${assigners}], v: ${delegator}, r: ${registrar}, ${lazyInspect(autoAccumulate)}) <- HUH`;
       regs.set(IN_OUT_REG, HostCallResult.HUH);
       return;
     }
 
     if (e === UpdatePrivilegesError.InvalidServiceId) {
-      logger.trace`[${this.currentServiceId}] BLESS(m: ${manager}, a: [${authorizers}], v: ${delegator}, r: ${registrar}, ${lazyInspect(autoAccumulate)}) <- WHO`;
+      logger.trace`[${this.currentServiceId}] BLESS(m: ${manager}, a: [${assigners}], v: ${delegator}, r: ${registrar}, ${lazyInspect(autoAccumulate)}) <- WHO`;
       regs.set(IN_OUT_REG, HostCallResult.WHO);
       return;
     }

--- a/packages/jam/jam-host-calls/externalities/partial-state.ts
+++ b/packages/jam/jam-host-calls/externalities/partial-state.ts
@@ -258,7 +258,7 @@ export interface PartialState {
    * Update priviliged services and their gas.
    *
    * `m`: manager service (can change privileged services)
-   * `a`: manages authorization queue
+   * `a`: per-core manager of authorization queue
    * `v`: manages validator keys
    * `r`: manages create new services in protected id range.
    * `z`: collection of serviceId -> gas that auto-accumulate every block

--- a/packages/jam/transition/accumulate/accumulation-result-merge-utils.ts
+++ b/packages/jam/transition/accumulate/accumulation-result-merge-utils.ts
@@ -95,69 +95,79 @@ function mergePrivilegedServices(mergeContext: MergeContext, [serviceId, { state
   const currentAssigners = currentPrivilegedServices.assigners;
   const { privilegedServices } = stateUpdate;
 
-  if (privilegedServices !== null) {
-    if (outputState.privilegedServices === null) {
-      outputState.privilegedServices = PrivilegedServices.create({
-        ...currentPrivilegedServices,
-      });
-    }
+  if (privilegedServices === null) {
+    return;
+  }
 
-    if (serviceId === currentManager) {
-      outputState.privilegedServices = PrivilegedServices.create({
-        ...privilegedServices,
-      });
-    }
-
-    if (serviceId === currentRegistrar) {
-      const newRegistrar = updatePrivilegedService(
-        currentPrivilegedServices.registrar,
-        privilegedServicesUpdatedByManager.registrar,
-        privilegedServices.registrar,
-      );
-
-      outputState.privilegedServices = PrivilegedServices.create({
-        ...outputState.privilegedServices,
-        registrar: newRegistrar,
-      });
-    }
-
-    if (serviceId === currentDelegator) {
-      const newDelegator = updatePrivilegedService(
-        currentPrivilegedServices.delegator,
-        privilegedServicesUpdatedByManager.delegator,
-        privilegedServices.delegator,
-      );
-      outputState.privilegedServices = PrivilegedServices.create({
-        ...outputState.privilegedServices,
-        delegator: newDelegator,
-      });
-    }
-
-    let shouldUpdateAssigners = false;
-
-    const newAssigners = currentAssigners.map((currentAssigner, coreIndex) => {
-      if (serviceId === currentAssigner) {
-        const newAssigner = updatePrivilegedService(
-          currentPrivilegedServices.assigners[coreIndex],
-          privilegedServicesUpdatedByManager.assigners[coreIndex],
-          privilegedServices.assigners[coreIndex],
-        );
-
-        shouldUpdateAssigners = shouldUpdateAssigners || newAssigner !== currentAssigner;
-
-        return newAssigner;
-      }
-
-      return currentAssigner;
+  // initial value (ignore the update, because it might not be authorized)
+  if (outputState.privilegedServices === null) {
+    outputState.privilegedServices = PrivilegedServices.create({
+      ...currentPrivilegedServices,
     });
+  }
 
-    if (shouldUpdateAssigners) {
-      const newAssignersPerCore = tryAsPerCore(newAssigners, chainSpec);
-      outputState.privilegedServices = PrivilegedServices.create({
-        ...outputState.privilegedServices,
-        assigners: newAssignersPerCore,
-      });
+  // manager can override everything and it always takes precedence over
+  // everything else
+  if (serviceId === currentManager) {
+    outputState.privilegedServices = PrivilegedServices.create({
+      ...privilegedServices,
+    });
+  }
+
+  // current registrar can transfer out it's permissions, but only if
+  // it wasn't overwritten by manager in current run
+  if (serviceId === currentRegistrar) {
+    const newRegistrar = updatePrivilegedService(
+      currentPrivilegedServices.registrar,
+      privilegedServicesUpdatedByManager.registrar,
+      privilegedServices.registrar,
+    );
+
+    outputState.privilegedServices = PrivilegedServices.create({
+      ...outputState.privilegedServices,
+      registrar: newRegistrar,
+    });
+  }
+
+  // current delegator can transfer out it's permissions, but only if
+  // it wasn't overwritten by manager in current run
+  if (serviceId === currentDelegator) {
+    const newDelegator = updatePrivilegedService(
+      currentPrivilegedServices.delegator,
+      privilegedServicesUpdatedByManager.delegator,
+      privilegedServices.delegator,
+    );
+    outputState.privilegedServices = PrivilegedServices.create({
+      ...outputState.privilegedServices,
+      delegator: newDelegator,
+    });
+  }
+
+  let shouldUpdateAssigners = false;
+
+  // same with assigners - they are free to transfer out their core
+  const newAssigners = currentAssigners.map((currentAssigner, coreIndex) => {
+    if (serviceId === currentAssigner) {
+      const newAssigner = updatePrivilegedService(
+        currentPrivilegedServices.assigners[coreIndex],
+        privilegedServicesUpdatedByManager.assigners[coreIndex],
+        privilegedServices.assigners[coreIndex],
+      );
+
+      shouldUpdateAssigners = shouldUpdateAssigners || newAssigner !== currentAssigner;
+
+      return newAssigner;
     }
+
+    return currentAssigner;
+  });
+
+  if (shouldUpdateAssigners) {
+    const newAssignersPerCore = tryAsPerCore(newAssigners, chainSpec);
+    outputState.privilegedServices = PrivilegedServices.create({
+      ...outputState.privilegedServices,
+      assigners: newAssignersPerCore,
+    });
   }
 }
 

--- a/packages/jam/transition/externalities/accumulate-externalities.test.ts
+++ b/packages/jam/transition/externalities/accumulate-externalities.test.ts
@@ -15,6 +15,7 @@ import { tinyChainSpec } from "@typeberry/config";
 import { BANDERSNATCH_KEY_BYTES, BLS_KEY_BYTES, ED25519_KEY_BYTES } from "@typeberry/crypto";
 import { Blake2b, HASH_SIZE } from "@typeberry/hash";
 import {
+  CURRENT_SERVICE_ID,
   EjectError,
   ForgetPreimageError,
   NewServiceError,
@@ -1203,8 +1204,9 @@ describe("PartialState.upgradeService", () => {
 });
 
 describe("PartialState.updateAuthorizationQueue", () => {
-  it("should update the authorization queue for a given core index", () => {
+  it("should update the authorization queue and transfer the assigner for the given core", () => {
     const state = partiallyUpdatedState();
+    const initialPrivileged = state.state.privilegedServices;
     const partialState = new AccumulateExternalities(
       tinyChainSpec,
       blake2b,
@@ -1215,17 +1217,29 @@ describe("PartialState.updateAuthorizationQueue", () => {
     );
 
     const coreIndex = tryAsCoreIndex(0);
-    const assigners = tryAsServiceId(0);
+    const newAssigner = tryAsServiceId(99);
     const queue = FixedSizeArray.new(
       Array.from({ length: AUTHORIZATION_QUEUE_SIZE }, () => Bytes.fill(HASH_SIZE, 0xee).asOpaque()),
       AUTHORIZATION_QUEUE_SIZE,
     );
 
     // when
-    partialState.updateAuthorizationQueue(coreIndex, queue, assigners);
+    const result = partialState.updateAuthorizationQueue(coreIndex, queue, newAssigner);
 
     // then
+    deepEqual(result, Result.ok(OK));
     assert.deepStrictEqual(state.stateUpdate.authorizationQueues.get(coreIndex), queue);
+
+    // the privilegedServices update must be written, with only the targeted
+    // core's assigner transferred; all other fields must be preserved.
+    const updated = state.stateUpdate.privilegedServices;
+    assert.ok(updated !== null, "stateUpdate.privilegedServices should be written");
+    assert.strictEqual(updated.assigners[0], newAssigner);
+    assert.strictEqual(updated.assigners[1], initialPrivileged.assigners[1]);
+    assert.strictEqual(updated.manager, initialPrivileged.manager);
+    assert.strictEqual(updated.delegator, initialPrivileged.delegator);
+    assert.strictEqual(updated.registrar, initialPrivileged.registrar);
+    assert.strictEqual(updated.autoAccumulateServices, initialPrivileged.autoAccumulateServices);
   });
 
   it("should return InvalidServiceId when given auth manager is invalid", () => {
@@ -1255,6 +1269,8 @@ describe("PartialState.updateAuthorizationQueue", () => {
       Result.error(UpdatePrivilegesError.InvalidServiceId, () => "New auth manager is null for core 0"),
     );
     assert.deepStrictEqual(state.stateUpdate.authorizationQueues.get(coreIndex), undefined);
+    // no partial privilegedServices write on error
+    assert.strictEqual(state.stateUpdate.privilegedServices, null);
   });
 
   it("should return UnprivilegedService when current service is not privileged", () => {
@@ -1288,6 +1304,8 @@ describe("PartialState.updateAuthorizationQueue", () => {
       Result.error(UpdatePrivilegesError.UnprivilegedService, () => "Service 0 not assigner for core 0 (expected: 1)"),
     );
     assert.deepStrictEqual(state.stateUpdate.authorizationQueues.get(coreIndex), undefined);
+    // no partial privilegedServices write on error
+    assert.strictEqual(state.stateUpdate.privilegedServices, null);
   });
 
   it("should return UnprivilegedService before InvalidServiceId if given auth manager is incorrect, but current servis is also unprivileged", () => {
@@ -1321,6 +1339,97 @@ describe("PartialState.updateAuthorizationQueue", () => {
       Result.error(UpdatePrivilegesError.UnprivilegedService, () => "Service 0 not assigner for core 0 (expected: 1)"),
     );
     assert.deepStrictEqual(state.stateUpdate.authorizationQueues.get(coreIndex), undefined);
+    // no partial privilegedServices write on error
+    assert.strictEqual(state.stateUpdate.privilegedServices, null);
+  });
+
+  it("should succeed on a self-transfer using CURRENT_SERVICE_ID", () => {
+    const state = partiallyUpdatedState();
+    // inject a service info for CURRENT_SERVICE_ID so it can act as the
+    // current (and assigning) service on core 0
+    const baseService = state.state.services.get(tryAsServiceId(0));
+    if (baseService === undefined) {
+      throw new Error("Invalid service!");
+    }
+    state.state.services.set(
+      CURRENT_SERVICE_ID,
+      new InMemoryService(CURRENT_SERVICE_ID, {
+        info: baseService.data.info,
+        preimages: HashDictionary.new(),
+        lookupHistory: HashDictionary.new(),
+        storage: new Map(),
+      }),
+    );
+    state.state.privilegedServices = PrivilegedServices.create({
+      ...state.state.privilegedServices,
+      assigners: asOpaqueType(FixedSizeArray.new([CURRENT_SERVICE_ID, tryAsServiceId(0)], tinyChainSpec.coresCount)),
+    });
+    const partialState = new AccumulateExternalities(
+      tinyChainSpec,
+      blake2b,
+      state,
+      CURRENT_SERVICE_ID,
+      tryAsServiceId(10),
+      tryAsTimeSlot(16),
+    );
+
+    const coreIndex = tryAsCoreIndex(0);
+    const queue = FixedSizeArray.new(
+      Array.from({ length: AUTHORIZATION_QUEUE_SIZE }, () => Bytes.fill(HASH_SIZE, 0xee).asOpaque()),
+      AUTHORIZATION_QUEUE_SIZE,
+    );
+
+    // when
+    const result = partialState.updateAuthorizationQueue(coreIndex, queue, CURRENT_SERVICE_ID);
+
+    // then
+    deepEqual(result, Result.ok(OK));
+    assert.deepStrictEqual(state.stateUpdate.authorizationQueues.get(coreIndex), queue);
+    const updated = state.stateUpdate.privilegedServices;
+    assert.ok(updated !== null, "stateUpdate.privilegedServices should be written");
+    assert.strictEqual(updated.assigners[0], CURRENT_SERVICE_ID);
+    assert.strictEqual(updated.assigners[1], tryAsServiceId(0));
+  });
+
+  it("should prevent the previous assigner from re-assigning after transfer", () => {
+    const state = partiallyUpdatedState();
+    const partialState = new AccumulateExternalities(
+      tinyChainSpec,
+      blake2b,
+      state,
+      tryAsServiceId(0),
+      tryAsServiceId(10),
+      tryAsTimeSlot(16),
+    );
+
+    const coreIndex = tryAsCoreIndex(0);
+    const newAssigner = tryAsServiceId(99);
+    const firstQueue = FixedSizeArray.new(
+      Array.from({ length: AUTHORIZATION_QUEUE_SIZE }, () => Bytes.fill(HASH_SIZE, 0xee).asOpaque()),
+      AUTHORIZATION_QUEUE_SIZE,
+    );
+    const secondQueue = FixedSizeArray.new(
+      Array.from({ length: AUTHORIZATION_QUEUE_SIZE }, () => Bytes.fill(HASH_SIZE, 0xff).asOpaque()),
+      AUTHORIZATION_QUEUE_SIZE,
+    );
+
+    // when: first call succeeds and transfers the assigner to service 99
+    const first = partialState.updateAuthorizationQueue(coreIndex, firstQueue, newAssigner);
+    // and the previous assigner (service 0) immediately tries to re-assign
+    const second = partialState.updateAuthorizationQueue(coreIndex, secondQueue, tryAsServiceId(0));
+
+    // then
+    deepEqual(first, Result.ok(OK));
+    deepEqual(
+      second,
+      Result.error(UpdatePrivilegesError.UnprivilegedService, () => "Service 0 not assigner for core 0 (expected: 99)"),
+    );
+    // the first queue remains — the failing second call must not overwrite it
+    assert.deepStrictEqual(state.stateUpdate.authorizationQueues.get(coreIndex), firstQueue);
+    // and the transferred assigner is still in place
+    const updated = state.stateUpdate.privilegedServices;
+    assert.ok(updated !== null);
+    assert.strictEqual(updated.assigners[0], newAssigner);
   });
 });
 

--- a/packages/jam/transition/externalities/accumulate-externalities.ts
+++ b/packages/jam/transition/externalities/accumulate-externalities.ts
@@ -13,7 +13,7 @@ import { MIN_PUBLIC_SERVICE_INDEX } from "@typeberry/block/gp-constants.js";
 import type { PreimageHash } from "@typeberry/block/preimage.js";
 import type { AuthorizerHash } from "@typeberry/block/refine-context.js";
 import { Bytes, type BytesBlob } from "@typeberry/bytes";
-import type { FixedSizeArray } from "@typeberry/collections";
+import { asKnownSize, type FixedSizeArray } from "@typeberry/collections";
 import type { ChainSpec } from "@typeberry/config";
 import { type Blake2b, HASH_SIZE, type OpaqueHash } from "@typeberry/hash";
 import {
@@ -539,22 +539,24 @@ export class AccumulateExternalities
   updateAuthorizationQueue(
     coreIndex: CoreIndex,
     authQueue: FixedSizeArray<AuthorizerHash, AUTHORIZATION_QUEUE_SIZE>,
-    assigners: ServiceId | null,
+    newAssigner: ServiceId | null,
   ): Result<OK, UpdatePrivilegesError> {
     /** https://graypaper.fluffylabs.dev/#/7e6ff6a/36a40136a401?v=0.6.7 */
 
     // NOTE `coreIndex` is already verified in the HC, so this is infallible.
-    const currentAssigners = this.updatedState.getPrivilegedServices().assigners[coreIndex];
+    const privilegedServices = this.updatedState.getPrivilegedServices();
+    const currentAssigners = privilegedServices.assigners;
+    const assigner = currentAssigners[coreIndex];
 
-    if (currentAssigners !== this.currentServiceId) {
-      logger.trace`Current service id (${this.currentServiceId}) is not an auth manager of core ${coreIndex} (expected: ${currentAssigners}) and cannot update authorization queue.`;
+    if (assigner !== this.currentServiceId) {
+      logger.trace`Current service id (${this.currentServiceId}) is not an auth manager of core ${coreIndex} (expected: ${assigner}) and cannot update authorization queue.`;
       return Result.error(
         UpdatePrivilegesError.UnprivilegedService,
-        () => `Service ${this.currentServiceId} not assigner for core ${coreIndex} (expected: ${currentAssigners})`,
+        () => `Service ${this.currentServiceId} not assigner for core ${coreIndex} (expected: ${assigner})`,
       );
     }
 
-    if (assigners === null) {
+    if (newAssigner === null) {
       logger.trace`The new auth manager is not a valid service id.`;
       return Result.error(
         UpdatePrivilegesError.InvalidServiceId,
@@ -562,7 +564,17 @@ export class AccumulateExternalities
       );
     }
 
+    // update the authorization queue
     this.updatedState.stateUpdate.authorizationQueues.set(coreIndex, authQueue);
+    // move permissions to the new assigner
+    const assigners = currentAssigners.slice();
+    assigners[coreIndex] = newAssigner;
+    this.updatedState.stateUpdate.privilegedServices = PrivilegedServices.create({
+      ...privilegedServices,
+      // since coreindex is validated, we do not alter the size,
+      // hence it's safe to convert back
+      assigners: asKnownSize(assigners),
+    });
     return Result.ok(OK);
   }
 


### PR DESCRIPTION
Our current `assign` host call implementation is broken. It disregards the assigner permision switch. This PR fixes that and also improves the documentation of that code paths.
