### PR TITLE
Hybrid States DB

### DIFF
--- a/bin/jam/README.md
+++ b/bin/jam/README.md
@@ -157,9 +157,7 @@ falls back to in-memory. The hybrid backend keeps the trie-leaf sets in memory
 (so it still prunes at finality depth 10_000 to bound memory, like the in-memory
 backend) but persists the large values to an on-disk LMDB store fronted by an
 in-memory LRU cache. This keeps memory bounded while the large values live on
-disk. Because leaf sets are pruned, the fuzzer can query the state of past
-blocks only within the pruning window (roughly the last 20_000 blocks), not the
-whole session.
+disk. 
 
 **Docker example:**
 

--- a/bin/jam/README.md
+++ b/bin/jam/README.md
@@ -145,18 +145,21 @@ contract.
 | `JAM_FUZZ` | Yes (any non-empty value) | Activates fuzz mode. |
 | `JAM_FUZZ_SPEC` | Yes | Chain spec: `tiny` or `full`. |
 | `JAM_FUZZ_SOCK_PATH` | Yes | Unix domain socket path the target listens on. |
-| `JAM_FUZZ_DATA_PATH` | No | Database location. A real path runs the target against an on-disk LMDB database (recommended for full-spec runs, to bound memory). Unset, empty, or `undefined` keeps the in-memory database (the default). |
+| `JAM_FUZZ_DATA_PATH` | No | Database location. A real path runs the target against the hybrid backend (in-memory leaves plus an on-disk LMDB value store, recommended for full-spec runs to bound memory). Unset, empty, or `undefined` keeps the fully in-memory database (the default). |
 | `JAM_FUZZ_LOG_LEVEL` | No | Log verbosity: `error`, `warn`, `info`, `debug`, `trace`. Overrides `JAM_LOG` in fuzz mode. |
 
 The target stays up across multiple fuzzer sessions; on each `Initialize`
 message it resets the state to the genesis sent by the fuzzer. By default the
-state is held in memory. If `JAM_FUZZ_DATA_PATH` points at a real directory, the
-target uses an on-disk LMDB database instead (wiped on every reset, so each
-session starts clean); if that database cannot be opened it logs a warning and
-falls back to in-memory. On the on-disk backend pruning is disabled, so every
-block's state is retained for the whole session (this grows disk, not memory),
-which lets the fuzzer query the state of any past block. The in-memory backend
-keeps pruning enabled to bound memory.
+state is held entirely in memory. If `JAM_FUZZ_DATA_PATH` points at a real
+directory, the target uses a hybrid backend instead (wiped on every reset, so
+each session starts clean); if that store cannot be opened it logs a warning and
+falls back to in-memory. The hybrid backend keeps the trie-leaf sets in memory
+(so it still prunes at finality depth 10_000 to bound memory, like the in-memory
+backend) but persists the large values to an on-disk LMDB store fronted by an
+in-memory LRU cache. This keeps memory bounded while the large values live on
+disk. Because leaf sets are pruned, the fuzzer can query the state of past
+blocks only within the pruning window (roughly the last 20_000 blocks), not the
+whole session.
 
 **Docker example:**
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,4 +1,5 @@
 {
+  "root": false,
   "$schema": "https://biomejs.dev/schemas/2.3.4/schema.json",
   "formatter": {
     "enabled": true,

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,4 @@
 {
-  "root": false,
   "$schema": "https://biomejs.dev/schemas/2.3.4/schema.json",
   "formatter": {
     "enabled": true,

--- a/packages/jam/database-lmdb/hybrid-states.test.ts
+++ b/packages/jam/database-lmdb/hybrid-states.test.ts
@@ -10,7 +10,6 @@ import { InMemoryState } from "@typeberry/state";
 import { StateEntries, type StateKey } from "@typeberry/state-merkleization";
 import { deepEqual, OK, Result } from "@typeberry/utils";
 import { HybridSerializedStates } from "./hybrid-states.js";
-import { LmdbRoot } from "./root.js";
 
 let blake2b: Blake2b;
 before(async () => {
@@ -24,18 +23,21 @@ function createTempDir(suffix = "hybrid"): string {
 describe("Hybrid serialized states", () => {
   const spec = tinyChainSpec;
   const headerHash: HeaderHash = Bytes.zero(HASH_SIZE).asOpaque();
-  let tmpDir = "";
+  let dbPath = "";
 
   beforeEach(() => {
-    tmpDir = createTempDir();
+    dbPath = createTempDir();
   });
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(dbPath, { recursive: true });
   });
 
   it("round-trips an initial state through the on-disk values store", async () => {
-    const root = LmdbRoot.new(tmpDir);
-    const states = HybridSerializedStates.new(spec, blake2b, root);
+    const states = HybridSerializedStates.new({
+      spec,
+      blake2b,
+      dbPath,
+    });
     try {
       const empty = InMemoryState.empty(spec);
       const serialized = StateEntries.serializeInMemory(spec, blake2b, empty);
@@ -55,8 +57,7 @@ describe("Hybrid serialized states", () => {
   });
 
   it("reads large values back from disk", async () => {
-    const root = LmdbRoot.new(tmpDir);
-    const states = HybridSerializedStates.new(spec, blake2b, root);
+    const states = HybridSerializedStates.new({ spec, blake2b, dbPath });
     try {
       // > 32 bytes => stored in the values db (not embedded in the leaf).
       const big1 = BytesBlob.blobFromString("x".repeat(100));
@@ -81,8 +82,7 @@ describe("Hybrid serialized states", () => {
   });
 
   it("drops the leaf set on markUnused while values stay on disk", async () => {
-    const root = LmdbRoot.new(tmpDir);
-    const states = HybridSerializedStates.new(spec, blake2b, root);
+    const states = HybridSerializedStates.new({ spec, blake2b, dbPath });
     try {
       const empty = InMemoryState.empty(spec);
       const serialized = StateEntries.serializeInMemory(spec, blake2b, empty);

--- a/packages/jam/database-lmdb/hybrid-states.test.ts
+++ b/packages/jam/database-lmdb/hybrid-states.test.ts
@@ -1,0 +1,98 @@
+// packages/jam/database-lmdb/hybrid-states.test.ts
+import assert from "node:assert";
+import * as fs from "node:fs";
+import { afterEach, before, beforeEach, describe, it } from "node:test";
+import type { HeaderHash } from "@typeberry/block";
+import { Bytes, BytesBlob } from "@typeberry/bytes";
+import { tinyChainSpec } from "@typeberry/config";
+import { Blake2b, HASH_SIZE } from "@typeberry/hash";
+import { InMemoryState } from "@typeberry/state";
+import { StateEntries, type StateKey } from "@typeberry/state-merkleization";
+import { deepEqual, OK, Result } from "@typeberry/utils";
+import { HybridSerializedStates } from "./hybrid-states.js";
+import { LmdbRoot } from "./root.js";
+
+let blake2b: Blake2b;
+before(async () => {
+  blake2b = await Blake2b.createHasher();
+});
+
+function createTempDir(suffix = "hybrid"): string {
+  return fs.mkdtempSync(`typeberry-${suffix}`);
+}
+
+describe("Hybrid serialized states", () => {
+  const spec = tinyChainSpec;
+  const headerHash: HeaderHash = Bytes.zero(HASH_SIZE).asOpaque();
+  let tmpDir = "";
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it("round-trips an initial state through the on-disk values store", async () => {
+    const root = LmdbRoot.new(tmpDir);
+    const states = HybridSerializedStates.new(spec, blake2b, root);
+    try {
+      const empty = InMemoryState.empty(spec);
+      const serialized = StateEntries.serializeInMemory(spec, blake2b, empty);
+      const expectedRoot = serialized.getRootHash(blake2b);
+
+      const res = await states.insertInitialState(headerHash, serialized);
+      deepEqual(res, Result.ok(OK));
+
+      const state = states.getState(headerHash);
+      assert.ok(state !== null);
+      const stateRoot = await states.getStateRoot(state);
+      assert.strictEqual(`${stateRoot}`, `${expectedRoot}`);
+      deepEqual(InMemoryState.copyFrom(spec, state, new Map()), empty);
+    } finally {
+      await states.close();
+    }
+  });
+
+  it("reads large values back from disk", async () => {
+    const root = LmdbRoot.new(tmpDir);
+    const states = HybridSerializedStates.new(spec, blake2b, root);
+    try {
+      // > 32 bytes => stored in the values db (not embedded in the leaf).
+      const big1 = BytesBlob.blobFromString("x".repeat(100));
+      const big2 = BytesBlob.blobFromString("y".repeat(100));
+      const key1: StateKey = Bytes.fill(HASH_SIZE, 1).asOpaque();
+      const key2: StateKey = Bytes.fill(HASH_SIZE, 2).asOpaque();
+      const entries = StateEntries.fromEntriesUnsafe([
+        [key1, big1],
+        [key2, big2],
+      ]);
+
+      const res = await states.insertInitialState(headerHash, entries);
+      deepEqual(res, Result.ok(OK));
+
+      const state = states.getState(headerHash);
+      assert.ok(state !== null);
+      assert.strictEqual(`${state.backend.get(key2)}`, `${big2}`);
+      assert.strictEqual(`${state.backend.get(key1)}`, `${big1}`);
+    } finally {
+      await states.close();
+    }
+  });
+
+  it("drops the leaf set on markUnused while values stay on disk", async () => {
+    const root = LmdbRoot.new(tmpDir);
+    const states = HybridSerializedStates.new(spec, blake2b, root);
+    try {
+      const empty = InMemoryState.empty(spec);
+      const serialized = StateEntries.serializeInMemory(spec, blake2b, empty);
+      await states.insertInitialState(headerHash, serialized);
+      assert.ok(states.getState(headerHash) !== null);
+
+      states.markUnused(headerHash);
+      assert.strictEqual(states.getState(headerHash), null);
+    } finally {
+      await states.close();
+    }
+  });
+});

--- a/packages/jam/database-lmdb/hybrid-states.ts
+++ b/packages/jam/database-lmdb/hybrid-states.ts
@@ -21,7 +21,7 @@ import {
 } from "@typeberry/state-merkleization";
 import { type LeafNode, leafComparator, type ValueHash } from "@typeberry/trie";
 import { OK, Result } from "@typeberry/utils";
-import type { LmdbRoot, SubDb } from "./root.js";
+import { LmdbRoot, type SubDb } from "./root.js";
 
 /**
  * Hybrid serialized-states db.
@@ -37,7 +37,20 @@ export class HybridSerializedStates implements StatesDb<SerializedState<LeafDb>>
   // A single shared values accessor reused by every `LeafDb` we hand out.
   private readonly valuesDb: ValuesDb;
 
-  static new(spec: ChainSpec, blake2b: Blake2b, root: LmdbRoot) {
+  static new({
+    spec,
+    blake2b,
+    dbPath,
+    readOnly,
+    ephemeral,
+  }: {
+    spec: ChainSpec;
+    blake2b: Blake2b;
+    dbPath: string;
+    readOnly?: boolean;
+    ephemeral?: boolean;
+  }) {
+    const root = LmdbRoot.new(dbPath, readOnly, ephemeral);
     return new HybridSerializedStates(spec, blake2b, root);
   }
 
@@ -107,6 +120,7 @@ export class HybridSerializedStates implements StatesDb<SerializedState<LeafDb>>
 
   async close() {
     await this.lmdbValues.close();
+    await this.root.close();
   }
 
   /** Write new large values to LMDB in one transaction. */

--- a/packages/jam/database-lmdb/hybrid-states.ts
+++ b/packages/jam/database-lmdb/hybrid-states.ts
@@ -1,0 +1,137 @@
+// packages/jam/database-lmdb/hybrid-states.ts
+import type { HeaderHash, StateRootHash } from "@typeberry/block";
+import type { BytesBlob } from "@typeberry/bytes";
+import { HashDictionary, SortedSet } from "@typeberry/collections";
+import type { ChainSpec } from "@typeberry/config";
+import {
+  type InitStatesDb,
+  LeafDb,
+  type StatesDb,
+  StateUpdateError,
+  updateLeafs,
+  type ValuesDb,
+} from "@typeberry/database";
+import type { Blake2b } from "@typeberry/hash";
+import type { ServicesUpdate, State } from "@typeberry/state";
+import {
+  SerializedState,
+  type StateEntries,
+  StateEntryUpdateAction,
+  serializeStateUpdate,
+} from "@typeberry/state-merkleization";
+import { type LeafNode, leafComparator, type ValueHash } from "@typeberry/trie";
+import { OK, Result } from "@typeberry/utils";
+import type { LmdbRoot, SubDb } from "./root.js";
+
+/**
+ * Hybrid serialized-states db.
+ *
+ * States (leafs) are kept in-memory, but large values are persisted to lmdb.
+ * Reads go straight to lmdb, which keeps its own page cache.
+ * NOTE: this DB is designed for long fuzzing and to be used with pruning to
+ * keep the heap usage bounded.
+ */
+export class HybridSerializedStates implements StatesDb<SerializedState<LeafDb>>, InitStatesDb<StateEntries> {
+  private readonly inMemStates: HashDictionary<HeaderHash, SortedSet<LeafNode>> = HashDictionary.new();
+  private readonly lmdbValues: SubDb;
+  // A single shared values accessor reused by every `LeafDb` we hand out.
+  private readonly valuesDb: ValuesDb;
+
+  static new(spec: ChainSpec, blake2b: Blake2b, root: LmdbRoot) {
+    return new HybridSerializedStates(spec, blake2b, root);
+  }
+
+  private constructor(
+    private readonly spec: ChainSpec,
+    private readonly blake2b: Blake2b,
+    private readonly root: LmdbRoot,
+  ) {
+    this.lmdbValues = this.root.subDb("values");
+    this.valuesDb = { get: (key: ValueHash) => this.readValue(key) };
+  }
+
+  async insertInitialState(headerHash: HeaderHash, entries: StateEntries): Promise<Result<OK, StateUpdateError>> {
+    const { values, leafs } = updateLeafs(
+      SortedSet.fromArray(leafComparator, []),
+      this.blake2b,
+      Array.from(entries, (x) => [StateEntryUpdateAction.Insert, x[0], x[1]]),
+    );
+    const res = await this.writeValues(values);
+    if (res.isError) {
+      return res;
+    }
+    this.inMemStates.set(headerHash, leafs);
+    return Result.ok(OK);
+  }
+
+  async updateAndSetState(
+    header: HeaderHash,
+    state: SerializedState<LeafDb>,
+    update: Partial<State & ServicesUpdate>,
+  ): Promise<Result<OK, StateUpdateError>> {
+    const updatedValues = serializeStateUpdate(this.spec, this.blake2b, update);
+    // Clone the leaf set before mutating: the previous state keeps using its own.
+    const newLeafs = SortedSet.fromSortedArray(leafComparator, state.backend.leafs.array);
+    const { values, leafs } = updateLeafs(newLeafs, this.blake2b, updatedValues);
+    const res = await this.writeValues(values);
+    if (res.isError) {
+      // Leave the caller's state untouched: its new leaves would reference
+      // values that never reached disk.
+      return res;
+    }
+    // Re-create the lookup with the shared values accessor only once the new
+    // values are durably written.
+    state.updateBackend(LeafDb.fromLeaves(leafs, this.valuesDb));
+    this.inMemStates.set(header, leafs);
+    return Result.ok(OK);
+  }
+
+  async getStateRoot(state: SerializedState<LeafDb>): Promise<StateRootHash> {
+    return state.backend.getStateRoot(this.blake2b);
+  }
+
+  getState(header: HeaderHash): SerializedState<LeafDb> | null {
+    const leafs = this.inMemStates.get(header);
+    if (leafs === undefined) {
+      return null;
+    }
+    const leafDb = LeafDb.fromLeaves(leafs, this.valuesDb);
+    return SerializedState.new(this.spec, this.blake2b, leafDb);
+  }
+
+  markUnused(header: HeaderHash): void {
+    // We only remove the state from memory - values are not pruned at all,
+    // but since they are stored on disk we should be safe.
+    this.inMemStates.delete(header);
+  }
+
+  async close() {
+    await this.lmdbValues.close();
+  }
+
+  /** Write new large values to LMDB in one transaction. */
+  private async writeValues(values: [ValueHash, BytesBlob][]): Promise<Result<OK, StateUpdateError>> {
+    if (values.length === 0) {
+      return Result.ok(OK);
+    }
+    try {
+      await this.lmdbValues.transaction(() => {
+        for (const [hash, val] of values) {
+          this.lmdbValues.put(hash.raw, val.raw);
+        }
+      });
+    } catch (e) {
+      return Result.error(StateUpdateError.Commit, () => `Failed to commit values: ${e}`);
+    }
+    return Result.ok(OK);
+  }
+
+  /** Read a value from LMDB. */
+  private readValue(key: ValueHash): Uint8Array {
+    const val = this.lmdbValues.get(key.raw);
+    if (val === undefined) {
+      throw new Error(`Missing value at key: ${key}`);
+    }
+    return val;
+  }
+}

--- a/packages/jam/database-lmdb/index.ts
+++ b/packages/jam/database-lmdb/index.ts
@@ -1,3 +1,4 @@
 export * from "./blocks.js";
+export * from "./hybrid-states.js";
 export * from "./root.js";
 export * from "./states.js";

--- a/packages/jam/node/main-fuzz.ts
+++ b/packages/jam/node/main-fuzz.ts
@@ -107,8 +107,6 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
       }
 
       const buildNode = (databaseBasePath: string | undefined) => {
-        // Enable state/blocks pruning only when running in memory.
-        // For disk backend, we store everything.
         const isPersistent = databaseBasePath !== undefined;
         return mainImporter(
           {
@@ -128,11 +126,14 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
           withRelPath,
           {
             initGenesisFromAncestry: fuzzConfig.initGenesisFromAncestry,
-            dummyFinalityDepth: isPersistent ? 0 : 10_000,
-            pruneBlocks: !isPersistent,
+            // Hybrid keeps leaf sets in RAM, so they must be windowed exactly
+            // like the in-memory backend; only the large values live on disk.
+            dummyFinalityDepth: 10_000,
+            pruneBlocks: true,
             // The fuzz db is wiped on every reset, so durability is pointless:
-            // skip fsync + compression to cut the per-block leaf write cost.
+            // skip fsync + compression to cut the per-block value write cost.
             ephemeralDb: isPersistent,
+            stateBackend: isPersistent ? "hybrid" : "lmdb",
           },
         );
       };

--- a/packages/jam/node/main-importer.ts
+++ b/packages/jam/node/main-importer.ts
@@ -6,7 +6,7 @@ import { Blake2b, HASH_SIZE } from "@typeberry/hash";
 import { createImporter, ImporterConfig } from "@typeberry/importer";
 import { tryAsU16 } from "@typeberry/numbers";
 import { CURRENT_SUITE, CURRENT_VERSION, Result, resultToString, version } from "@typeberry/utils";
-import { InMemWorkerConfig, LmdbWorkerConfig } from "@typeberry/workers-api-node";
+import { HybridWorkerConfig, InMemWorkerConfig, LmdbWorkerConfig } from "@typeberry/workers-api-node";
 import { getChainSpec, getDatabasePath, initializeDatabase, logger } from "./common.js";
 import type { JamConfig } from "./jam-config.js";
 import type { NodeApi } from "./main.js";
@@ -19,6 +19,8 @@ export type ImporterOptions = {
   pruneBlocks?: boolean;
   /** Open the LMDB database without fsync/compression. Only safe for throwaway dbs (e.g. fuzzing). */
   ephemeralDb?: boolean;
+  /** Persistent backend to use when `databaseBasePath` is set. Defaults to full LMDB. */
+  stateBackend?: "lmdb" | "hybrid";
 };
 
 export async function mainImporter(
@@ -58,14 +60,23 @@ export async function mainImporter(
           blake2b,
           workerParams,
         })
-      : LmdbWorkerConfig.new({
-          nodeName,
-          chainSpec,
-          blake2b,
-          dbPath,
-          workerParams,
-          ephemeral: options.ephemeralDb ?? false,
-        });
+      : options.stateBackend === "hybrid"
+        ? HybridWorkerConfig.new({
+            nodeName,
+            chainSpec,
+            blake2b,
+            dbPath,
+            workerParams,
+            ephemeral: options.ephemeralDb ?? false,
+          })
+        : LmdbWorkerConfig.new({
+            nodeName,
+            chainSpec,
+            blake2b,
+            dbPath,
+            workerParams,
+            ephemeral: options.ephemeralDb ?? false,
+          });
 
   // Initialize the database with genesis state and block if there isn't one.
   logger.info`🛢️ Opening database at ${dbPath}`;

--- a/packages/workers/api-node/config.ts
+++ b/packages/workers/api-node/config.ts
@@ -8,7 +8,7 @@ import {
   type RootDb,
   type SerializedStatesDb,
 } from "@typeberry/database";
-import { LmdbBlocks, LmdbRoot, LmdbStates } from "@typeberry/database-lmdb";
+import { HybridSerializedStates, LmdbBlocks, LmdbRoot, LmdbStates } from "@typeberry/database-lmdb";
 import { Blake2b } from "@typeberry/hash";
 import type { WorkerConfig } from "@typeberry/workers-api";
 import { ThreadPort, type TransferablePort } from "./port.js";
@@ -147,6 +147,65 @@ export class InMemWorkerConfig<T = undefined> implements WorkerConfig<T, BlocksD
     return {
       getBlocksDb: () => this.blocks,
       getStatesDb: () => this.states,
+      close: async () => {},
+    };
+  }
+}
+
+/**
+ * Hybrid worker config for the fuzz target: in-memory blocks and leaf sets,
+ * but large values persisted to LMDB.
+ *
+ * Like `InMemWorkerConfig`, the blocks and leaf sets are shared across the
+ * open/close/reopen dance that genesis init performs, so `openDatabase`
+ * returns the same instances and a no-op close. The LMDB root is opened once
+ * here and closed by `HybridSerializedStates.close()` at importer teardown.
+ *
+ * In-process only: it holds shared mutable state (the in-memory leaf
+ * dictionary) and so is not thread-transferable. The fuzz target runs the
+ * importer in-process via `createImporter`, not in a spawned worker.
+ */
+export class HybridWorkerConfig<T = undefined> implements WorkerConfig<T, BlocksDb, SerializedStatesDb> {
+  static new<T>({
+    nodeName,
+    chainSpec,
+    workerParams,
+    blake2b,
+    dbPath,
+    ephemeral = false,
+  }: {
+    nodeName: string;
+    chainSpec: ChainSpec;
+    workerParams: T;
+    blake2b: Blake2b;
+    dbPath: string;
+    ephemeral?: boolean;
+  }) {
+    return new HybridWorkerConfig(nodeName, chainSpec, workerParams, blake2b, dbPath, ephemeral);
+  }
+
+  private readonly blocks: InMemoryBlocks;
+  private readonly states: HybridSerializedStates;
+
+  private constructor(
+    public readonly nodeName: string,
+    public readonly chainSpec: ChainSpec,
+    public readonly workerParams: T,
+    public readonly blake2b: Blake2b,
+    public readonly dbPath: string,
+    public readonly ephemeral: boolean,
+  ) {
+    this.blocks = InMemoryBlocks.new();
+    const root = LmdbRoot.new(this.dbPath, false, this.ephemeral);
+    this.states = HybridSerializedStates.new(this.chainSpec, this.blake2b, root);
+  }
+
+  openDatabase(_options: { readonly: boolean } = { readonly: true }): RootDb<BlocksDb, SerializedStatesDb> {
+    return {
+      getBlocksDb: () => this.blocks,
+      getStatesDb: () => this.states,
+      // Leaf sets and blocks live in memory; the LMDB values store is closed
+      // via states.close() at importer teardown, so this is a no-op.
       close: async () => {},
     };
   }

--- a/packages/workers/api-node/config.ts
+++ b/packages/workers/api-node/config.ts
@@ -196,8 +196,13 @@ export class HybridWorkerConfig<T = undefined> implements WorkerConfig<T, Blocks
     public readonly ephemeral: boolean,
   ) {
     this.blocks = InMemoryBlocks.new();
-    const root = LmdbRoot.new(this.dbPath, false, this.ephemeral);
-    this.states = HybridSerializedStates.new(this.chainSpec, this.blake2b, root);
+    this.states = HybridSerializedStates.new({
+      spec: this.chainSpec,
+      blake2b: this.blake2b,
+      dbPath: this.dbPath,
+      ephemeral: this.ephemeral,
+      readOnly: false,
+    });
   }
 
   openDatabase(_options: { readonly: boolean } = { readonly: true }): RootDb<BlocksDb, SerializedStatesDb> {


### PR DESCRIPTION
This PR introduces a Hybrid (In-Mem + LMDB) database to use for fuzzing.

When running long fuzzing sessions the LMDB seems to exhaust available memory (yet to be fully confirmed), while `InMemory` db runs out of the heap space, presumably due to unpruned values.

This design uses in-memory for Blocks and States (with pruning), yet Values are stored in LMDB. The claim is that this should keep both heap and RSS memory in check.
