### PR TITLE
Fix fjall-hybrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1108,22 +1108,22 @@
       }
     },
     "node_modules/@fjall-js/fjall": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@fjall-js/fjall/-/fjall-0.1.3.tgz",
-      "integrity": "sha512-mwDaN47/KthyeGnC/R1ScMIwHyU0YZhy6O3T1p5QLKarYHwXqr40fTpFOOHodeSD4SFQa6+fOemjmCpCbo/pZA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fjall-js/fjall/-/fjall-0.2.0.tgz",
+      "integrity": "sha512-p740YeVFfGA8pffaeo32OU7UKzZIpQkd53XDfVThV8uMec/Ogzj6DQLYfVi4Lcc6Vq1me1qCmsmcekbMnDX0rA==",
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@fjall-js/fjall-darwin-arm64": "0.1.3",
-        "@fjall-js/fjall-linux-x64-gnu": "0.1.3"
+        "@fjall-js/fjall-darwin-arm64": "0.2.0",
+        "@fjall-js/fjall-linux-x64-gnu": "0.2.0"
       }
     },
     "node_modules/@fjall-js/fjall-darwin-arm64": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@fjall-js/fjall-darwin-arm64/-/fjall-darwin-arm64-0.1.3.tgz",
-      "integrity": "sha512-eVoF4amH/RKQDEqLN5kx7ayeuuCdb2YOcb93W0ptH8tB1+T1S36DnRA2jNnSViSL34PgeX3DSeke7BNjPU0XbQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fjall-js/fjall-darwin-arm64/-/fjall-darwin-arm64-0.2.0.tgz",
+      "integrity": "sha512-mE5dO/WLoyHbN1uNFlD+9zzbyLDPlqreYriSIa8T6KsO1kdnk4zDc9i1NDWJobRgmZTNSabR3es0OlZ0RseDDA==",
       "cpu": [
         "arm64"
       ],
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@fjall-js/fjall-linux-x64-gnu": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@fjall-js/fjall-linux-x64-gnu/-/fjall-linux-x64-gnu-0.1.3.tgz",
-      "integrity": "sha512-uew8LMvhb+SyeNISfoADti2VWFjmrBnEmWAN/tc0v+GH/H/iejNKVxt8FQYy+3Q4NVY1IdON0TT6mWu16QEkog==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fjall-js/fjall-linux-x64-gnu/-/fjall-linux-x64-gnu-0.2.0.tgz",
+      "integrity": "sha512-x8a42HdwZKR0y0OWU9D1apTUHHVueJUJROWq66LHj5+uwNsP7HlNYJD6+GwXsIy/gtKzPZrGtLFkS/BUtAq/rA==",
       "cpu": [
         "x64"
       ],
@@ -10506,7 +10506,7 @@
       "version": "0.9.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@fjall-js/fjall": "0.1.3",
+        "@fjall-js/fjall": "0.2.0",
         "@typeberry/block": "*",
         "@typeberry/bytes": "*",
         "@typeberry/collections": "*",

--- a/packages/jam/database-fjall/hybrid-states.test.ts
+++ b/packages/jam/database-fjall/hybrid-states.test.ts
@@ -8,7 +8,7 @@ import { Blake2b, HASH_SIZE } from "@typeberry/hash";
 import { InMemoryState } from "@typeberry/state";
 import { StateEntries, type StateKey } from "@typeberry/state-merkleization";
 import { deepEqual, OK, Result } from "@typeberry/utils";
-import { HybridSerializedStates } from "./hybrid-states.js";
+import { FjallValuesSession, HybridSerializedStates } from "./hybrid-states.js";
 
 let blake2b: Blake2b;
 before(async () => {
@@ -73,6 +73,39 @@ describe("Fjall hybrid serialized states", () => {
       assert.strictEqual(`${state.backend.get(key1)}`, `${big1}`);
     } finally {
       await states.close();
+    }
+  });
+
+  it("shares an open values session across resets without closing it", async () => {
+    // The fuzz reset path opens the values keyspace once per session and reuses
+    // it: each "reset" builds a fresh states instance sharing that session, and
+    // closing a session-backed states must NOT close the shared keyspace.
+    const session = await FjallValuesSession.open(dbPath);
+    try {
+      const big = BytesBlob.blobFromString("z".repeat(100));
+      const key: StateKey = Bytes.fill(HASH_SIZE, 7).asOpaque();
+      const entries = StateEntries.fromEntriesUnsafe([[key, big]]);
+
+      // First "reset": write values through a states instance, then close it.
+      const first = HybridSerializedStates.fromSession(spec, blake2b, session);
+      const res = await first.insertInitialState(headerHash, entries);
+      deepEqual(res, Result.ok(OK));
+      await first.close();
+
+      // Second "reset": a fresh states sharing the same session. Its in-memory
+      // leaf set is independent (empty until it inserts)...
+      const second = HybridSerializedStates.fromSession(spec, blake2b, session);
+      assert.strictEqual(second.getState(headerHash), null);
+
+      // ...but the on-disk values store is the same one, still open and usable
+      // (a closed keyspace would throw here).
+      await second.insertInitialState(headerHash, entries);
+      const state = second.getState(headerHash);
+      assert.ok(state !== null);
+      assert.strictEqual(`${state.backend.get(key)}`, `${big}`);
+      await second.close();
+    } finally {
+      await session.close();
     }
   });
 

--- a/packages/jam/database-fjall/hybrid-states.ts
+++ b/packages/jam/database-fjall/hybrid-states.ts
@@ -21,20 +21,59 @@ import {
 } from "@typeberry/state-merkleization";
 import { type LeafNode, leafComparator, type ValueHash } from "@typeberry/trie";
 import { OK, Result } from "@typeberry/utils";
-import { FjallRoot, type Partition, toUint8Array } from "./root.js";
+import { FjallRoot, type FjallRootOptions, type Partition, toUint8Array } from "./root.js";
 
 const logger = Logger.new(import.meta.filename, "db");
 
 /**
+ * One open fjall keyspace together with its content-addressed `values`
+ * partition.
+ *
+ * Opening the keyspace is the slow part, so the fuzz target opens one session
+ * per run and reuses it for every reset (see `HybridSerializedStates.fromSession`).
+ * The values partition is immutable - the key is the hash of the value - so it
+ * is fine that values pile up across resets, the unreferenced ones just sit
+ * there unused.
+ */
+export class FjallValuesSession {
+  private constructor(
+    private readonly root: FjallRoot,
+    /** Shared content-addressed values partition, reused across resets. */
+    readonly values: Partition,
+  ) {}
+
+  /** Open (or create) the keyspace at `dbPath` and its `values` partition. */
+  static async open(dbPath: string, options: FjallRootOptions = {}): Promise<FjallValuesSession> {
+    const root = await FjallRoot.open(dbPath, options);
+    const values = await root.partition("values");
+    return new FjallValuesSession(root, values);
+  }
+
+  /** Flush the journal to disk (a no-op for ephemeral keyspaces). */
+  async persist(): Promise<void> {
+    await this.root.persist();
+  }
+
+  /** Size of the keyspace directory on disk, in bytes. */
+  sizeInBytes(): number | null {
+    return this.root.sizeInBytes();
+  }
+
+  /** Release the keyspace handle (skips the sync-all fsync when ephemeral). */
+  async close(): Promise<void> {
+    await this.root.close();
+  }
+}
+
+/**
  * Hybrid serialized-states db (fjall variant).
  *
- * States (leafs) are kept in-memory, but large values are persisted to fjall.
- * Reads go straight to fjall, which keeps its own (bounded) block cache.
- * Designed for long fuzzing, used with pruning to keep heap usage bounded.
+ * States (leafs) are kept in memory, only the large values go to fjall on disk.
+ * Reads hit fjall directly, which keeps its own bounded block cache. Meant for
+ * long fuzzing, used together with pruning so the heap stays bounded.
  *
- * Behaviourally identical to the LMDB hybrid db; differences are mechanical:
- * construction is async, and value writes are ordered + flushed explicitly
- * because fjall has no transaction primitive.
+ * Construction is async, and value writes are flushed explicitly, because fjall
+ * has no transaction primitive.
  */
 export class HybridSerializedStates implements StatesDb<SerializedState<LeafDb>>, InitStatesDb<StateEntries> {
   static async new({
@@ -42,27 +81,45 @@ export class HybridSerializedStates implements StatesDb<SerializedState<LeafDb>>
     blake2b,
     dbPath,
     ephemeral,
+    cacheSizeBytes,
   }: {
     spec: ChainSpec;
     blake2b: Blake2b;
     dbPath: string;
     ephemeral?: boolean;
+    cacheSizeBytes?: number;
   }): Promise<HybridSerializedStates> {
-    const root = await FjallRoot.open(dbPath, { ephemeral });
-    const values = await root.partition("values");
-    return new HybridSerializedStates(spec, blake2b, root, values);
+    const session = await FjallValuesSession.open(dbPath, { ephemeral, cacheSizeBytes });
+    // This instance owns the session it just opened, so its `close()` closes it.
+    return new HybridSerializedStates(spec, blake2b, session, true);
+  }
+
+  /**
+   * Wrap an already-open `FjallValuesSession` and reuse its keyspace.
+   *
+   * The new instance starts with its own empty in-memory leaf sets but shares
+   * the values partition on disk. Its `close()` does not close the session, the
+   * session owner closes it once. The fuzz target uses this to keep one keyspace
+   * across resets and only rebuild the in-memory state for each vector.
+   */
+  static fromSession(spec: ChainSpec, blake2b: Blake2b, session: FjallValuesSession): HybridSerializedStates {
+    return new HybridSerializedStates(spec, blake2b, session, false);
   }
 
   private readonly inMemStates: HashDictionary<HeaderHash, SortedSet<LeafNode>> = HashDictionary.new();
   // A single shared values accessor reused by every `LeafDb` we hand out.
   private readonly valuesDb: ValuesDb;
+  /** Shared content-addressed values partition (owned by `session`). */
+  private readonly values: Partition;
 
   private constructor(
     private readonly spec: ChainSpec,
     private readonly blake2b: Blake2b,
-    private readonly root: FjallRoot,
-    private readonly values: Partition,
+    private readonly session: FjallValuesSession,
+    /** Whether `close()` should close the underlying session. */
+    private readonly ownsSession: boolean,
   ) {
+    this.values = session.values;
     this.valuesDb = { get: (key: ValueHash) => this.readValue(key) };
   }
 
@@ -122,23 +179,26 @@ export class HybridSerializedStates implements StatesDb<SerializedState<LeafDb>>
   }
 
   diskSizeInBytes(): number | null {
-    return this.root.sizeInBytes();
+    return this.session.sizeInBytes();
   }
 
   async close() {
-    await this.root.close();
+    // Instances backed by a shared session (fuzz reset reuse) keep the keyspace
+    // open for the next reset. The session owner closes it once.
+    if (this.ownsSession) {
+      await this.session.close();
+    }
   }
 
-  /** Write new large values to fjall, then flush. */
+  /** Write new large values to fjall in a single batch, then flush. */
   private async writeValues(values: [ValueHash, BytesBlob][]): Promise<Result<OK, StateUpdateError>> {
     if (values.length === 0) {
       return Result.ok(OK);
     }
     try {
-      for (const [hash, val] of values) {
-        await this.values.insert(hash.raw, val.raw);
-      }
-      await this.root.persist();
+      const entries = values.map(([hash, val]) => ({ key: hash.raw, value: val.raw }));
+      await this.values.insertBatch(entries);
+      await this.session.persist();
     } catch (e) {
       logger.error`${e}`;
       return Result.error(StateUpdateError.Commit, () => `Failed to commit values: ${e}`);

--- a/packages/jam/database-fjall/package.json
+++ b/packages/jam/database-fjall/package.json
@@ -9,7 +9,7 @@
   "author": "Fluffy Labs",
   "license": "MPL-2.0",
   "dependencies": {
-    "@fjall-js/fjall": "0.1.3",
+    "@fjall-js/fjall": "0.2.0",
     "@typeberry/block": "*",
     "@typeberry/bytes": "*",
     "@typeberry/collections": "*",

--- a/packages/jam/database-fjall/root.ts
+++ b/packages/jam/database-fjall/root.ts
@@ -16,21 +16,27 @@ export function toUint8Array(value: Buffer | null): Uint8Array | null {
 
 export type FjallRootOptions = {
   /**
-   * When set, durability flushes (`persist`) are skipped entirely.
+   * When set, we skip the durability flush (`persist`) and `close()` does not
+   * do the sync-all fsync.
    *
-   * Only safe for throwaway databases (e.g. the fuzz target, which wipes on
-   * every reset). Mirrors LMDB's `noSync`.
+   * Only safe for throwaway databases, like the fuzz target that wipes on every
+   * reset.
    */
   ephemeral?: boolean;
+  /**
+   * Cache size in bytes, shared by all partitions of the keyspace. fjall reads
+   * through this cache, so it bounds how much we keep in memory. When not set,
+   * fjall uses its own default.
+   */
+  cacheSizeBytes?: number;
 };
 
 /**
- * A thin abstraction over the fjall keyspace.
+ * Thin wrapper over the fjall keyspace.
  *
- * Unlike LMDB (a memory-mapped B-tree), fjall is an LSM-tree that reads/writes
- * through regular file I/O, so its working set is bounded by an explicit block
- * cache rather than the whole mmap. LMDB has been causing oom issues because
- * of that.
+ * fjall is an LSM-tree: it reads and writes through normal file i/o and keeps
+ * only a bounded block cache in memory, so the resident set stays bounded even
+ * when the store on disk is big.
  */
 export class FjallRoot {
   private constructor(
@@ -42,7 +48,12 @@ export class FjallRoot {
 
   /** Open (or create) a fjall keyspace at the given path. */
   static async open(dbPath: string, options: FjallRootOptions): Promise<FjallRoot> {
-    const keyspace = await open(dbPath);
+    // Forward our options to the binding: `ephemeral` makes `close()` skip the
+    // sync-all fsync, `cacheSizeBytes` bounds how much we keep in memory.
+    const keyspace = await open(dbPath, {
+      ephemeral: options.ephemeral,
+      cacheSizeBytes: options.cacheSizeBytes,
+    });
     return new FjallRoot(keyspace, dbPath, options);
   }
 
@@ -65,11 +76,11 @@ export class FjallRoot {
   }
 
   /**
-   * Apparent on-disk size of the keyspace directory, in bytes.
+   * Size of the keyspace directory on disk, in bytes.
    *
-   * Returns `null` if the directory cannot be walked (e.g. not yet created).
-   * Unlike LMDB's single `data.mdb`, a fjall keyspace is a directory of
-   * partition and journal files, so we sum it recursively.
+   * Returns `null` when the directory cannot be walked (e.g. not created yet).
+   * A fjall keyspace is a directory of partition and journal files, so we sum
+   * them recursively.
    */
   sizeInBytes(): number | null {
     try {

--- a/packages/jam/node/main-fuzz.ts
+++ b/packages/jam/node/main-fuzz.ts
@@ -9,7 +9,7 @@ import { HASH_SIZE } from "@typeberry/hash";
 import { Logger } from "@typeberry/logger";
 import type { StateEntries } from "@typeberry/state-merkleization";
 import { CURRENT_VERSION, Result, version } from "@typeberry/utils";
-import { logHostEnvironment } from "@typeberry/workers-api-node";
+import { FjallValuesSession, logHostEnvironment } from "@typeberry/workers-api-node";
 import { getChainSpec } from "./common.js";
 import type { JamConfig } from "./jam-config.js";
 import type { NodeApi } from "./main.js";
@@ -30,6 +30,15 @@ const FUZZ_DB_SUBDIR = "typeberry-fuzz-db";
 const FUZZ_DB_FJALL: StateBackend = "fjall-hybrid";
 const FUZZ_DB_LMDB: StateBackend = "lmdb-hybrid";
 const FUZZ_DB_OPTIONS: string[] = [FUZZ_DB_FJALL, FUZZ_DB_LMDB];
+
+/** Subdirectory (under the fuzzer's db dir) holding the reused fjall values keyspace. */
+const FUZZ_FJALL_VALUES_SUBDIR = "values-session";
+/**
+ * Size of the fjall block-cache for the fuzz session. Values pile up across
+ * resets (for fjall we do not wipe between them), so this cache is what keeps
+ * the resident memory bounded.
+ */
+const FUZZ_FJALL_CACHE_BYTES = 128 * 1024 * 1024;
 
 /**
  * Resolve the directory the fuzzer should use for its on-disk database, or
@@ -84,6 +93,10 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
   }
 
   let runningNode: NodeApi | null = null;
+  // The fjall values keyspace is opened once per fuzz session and reused on
+  // every reset, because opening it is the slow part. Only the in-memory blocks
+  // and leaf sets are rebuilt for each vector. fjall-hybrid only.
+  let fjallSession: FjallValuesSession | null = null;
 
   const chainSpec = getChainSpec(config.node.flavor);
 
@@ -144,22 +157,44 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
             // like the in-memory backend; only the large values live on disk.
             dummyFinalityDepth: 20,
             pruneBlocks: true,
-            // Long full-spec sessions accumulate a large, never-pruned values db.
-            // Syncing lets the OS reclaim dirty mmap pages, and compression (full
-            // spec only, where values are big) bounds its on-disk/page-cache size.
-            // Tiny stays uncompressed since its db is small and speed matters more.
+            // The on-disk fuzz db is throwaway (we wipe it), so open it ephemeral and
+            // skip the fsync, we do not need durability here. On full spec ephemeral
+            // also turns on compression further down, so the big values do not grow the
+            // db too much. Tiny stays uncompressed, its db is small and speed matters more.
             ephemeral: isPersistent,
             stateBackend: isPersistent ? hybridStateBackend : "lmdb",
+            // Reuse the session keyspace (fjall-hybrid only, other backends
+            // ignore it). Nothing to pass for the in-memory fallback.
+            sharedFjallSession: isPersistent ? (fjallSession ?? undefined) : undefined,
           },
         );
       };
 
       if (fuzzDbBase !== undefined) {
-        // Each reset starts a fresh session from the genesis the fuzzer just sent,
-        // so the on-disk db must be empty: otherwise initializeDatabase sees an
-        // already-initialized db and silently resumes the previous run's state.
-        await wipeFuzzDb(fuzzDbBase);
         try {
+          if (hybridStateBackend === FUZZ_DB_FJALL) {
+            // fjall-hybrid: open the values keyspace once and reuse it on every
+            // reset. The values partition is content-addressed and immutable, so
+            // it is fine that values pile up across resets, the unreferenced ones
+            // just sit there. `initializeDatabase` decides whether the db is
+            // already initialized from the in-memory blocks, which we rebuild on
+            // every reset, not from the values store, so reusing it does not
+            // resume the previous run.
+            if (fjallSession === null) {
+              // Start from a clean slate once, then keep the keyspace open.
+              await wipeFuzzDb(fuzzDbBase);
+              fjallSession = await FjallValuesSession.open(`${withRelPath(fuzzDbBase)}/${FUZZ_FJALL_VALUES_SUBDIR}`, {
+                ephemeral: true,
+                cacheSizeBytes: FUZZ_FJALL_CACHE_BYTES,
+              });
+              logger.info`🗄️ Opened reusable fjall values session at ${withRelPath(fuzzDbBase)}/${FUZZ_FJALL_VALUES_SUBDIR}`;
+            }
+          } else {
+            // lmdb-hybrid: keep the old behaviour, wipe and reopen on every
+            // reset. A fresh db each reset makes `initializeDatabase` set up
+            // genesis again instead of resuming the previous run.
+            await wipeFuzzDb(fuzzDbBase);
+          }
           runningNode = await buildNode(fuzzDbBase);
           return await runningNode.getBestStateRootHash();
         } catch (e) {
@@ -176,9 +211,17 @@ export async function mainFuzz(fuzzConfig: FuzzConfig, withRelPath: (v: string) 
 
   return () => {
     closeFuzzTarget();
+    // Close the reused fjall values session (if any) before wiping its files, so
+    // the keyspace handle is released first.
+    const closed = fjallSession?.close() ?? Promise.resolve();
+    fjallSession = null;
     if (fuzzDbBase !== undefined) {
       // best-effort cleanup on shutdown; ignore failures (dir may already be gone).
-      wipeFuzzDb(fuzzDbBase).catch(() => {});
+      closed
+        .catch(() => {})
+        .finally(() => {
+          wipeFuzzDb(fuzzDbBase).catch(() => {});
+        });
     }
   };
 }

--- a/packages/jam/node/main-importer.ts
+++ b/packages/jam/node/main-importer.ts
@@ -7,7 +7,12 @@ import { Blake2b, HASH_SIZE } from "@typeberry/hash";
 import { createImporter, ImporterConfig } from "@typeberry/importer";
 import { tryAsU16 } from "@typeberry/numbers";
 import { CURRENT_SUITE, CURRENT_VERSION, Result, resultToString, version } from "@typeberry/utils";
-import { HybridWorkerConfig, InMemWorkerConfig, LmdbWorkerConfig } from "@typeberry/workers-api-node";
+import {
+  type FjallValuesSession,
+  HybridWorkerConfig,
+  InMemWorkerConfig,
+  LmdbWorkerConfig,
+} from "@typeberry/workers-api-node";
 import { getChainSpec, getDatabasePath, initializeDatabase, logger } from "./common.js";
 import type { JamConfig } from "./jam-config.js";
 import type { NodeApi } from "./main.js";
@@ -23,9 +28,15 @@ export type ImporterOptions = {
   /** Open the database without fsync/compression. Only safe for throwaway dbs (e.g. fuzzing). */
   ephemeral?: boolean;
   /**
-   * Persistent backend to use when `databaseBasePath` is set. Defaults to full LMDB.
+   * Persistent backend used when `databaseBasePath` is set. Defaults to full LMDB.
    */
   stateBackend?: StateBackend;
+  /**
+   * Reuse an already-open fjall values session instead of opening a fresh
+   * keyspace. Only used when `stateBackend === "fjall-hybrid"`. The fuzz target
+   * opens one per run and reuses it across resets.
+   */
+  sharedFjallSession?: FjallValuesSession;
 };
 
 export async function mainImporter(
@@ -84,6 +95,7 @@ export async function mainImporter(
             ephemeral,
             compression,
             backend: dbBackend === "lmdb-hybrid" ? "lmdb" : "fjall",
+            sharedFjallSession: options.sharedFjallSession,
           })
         : LmdbWorkerConfig.new({
             nodeName,

--- a/packages/workers/api-node/config.ts
+++ b/packages/workers/api-node/config.ts
@@ -8,7 +8,7 @@ import {
   type RootDb,
   type SerializedStatesDb,
 } from "@typeberry/database";
-import { HybridSerializedStates as FjallHybridSerializedStates } from "@typeberry/database-fjall";
+import { HybridSerializedStates as FjallHybridSerializedStates, FjallValuesSession } from "@typeberry/database-fjall";
 import {
   LmdbBlocks,
   HybridSerializedStates as LmdbHybridSerializedStates,
@@ -19,7 +19,11 @@ import { Blake2b } from "@typeberry/hash";
 import type { WorkerConfig } from "@typeberry/workers-api";
 import { ThreadPort, type TransferablePort } from "./port.js";
 
-/** A worker config that's usable in node.js and uses LMDB database backend. */
+// Re-exported so the fuzz target can open one values session per run and reuse
+// it across resets (see `HybridWorkerConfig` / `mainFuzz`).
+export { FjallValuesSession };
+
+/** Worker config for node.js, backed by the LMDB database. */
 export class LmdbWorkerConfig<T = void> implements WorkerConfig<T, BlocksDb, SerializedStatesDb> {
   static new<T>({
     nodeName,
@@ -67,7 +71,7 @@ export class LmdbWorkerConfig<T = void> implements WorkerConfig<T, BlocksDb, Ser
     public readonly dbPath: string,
     public readonly blake2b: Blake2b,
     public readonly ports: Map<string, ThreadPort>,
-    // When set, the underlying LMDB skips fsync. Only safe for throwaway
+    // When set, the underlying database skips fsync. Only safe for throwaway
     // databases (the fuzz target wipes on reset). Not transferred to worker
     // threads, so the durable main node path always gets the default.
     public readonly ephemeral: boolean = false,
@@ -166,11 +170,10 @@ export type HybridBackend = "lmdb" | "fjall";
 
 /**
  * Hybrid worker config for the fuzz target: in-memory blocks and leaf sets,
- * but large values persisted to disk (LMDB or fjall, selected by `backend`).
+ * but large values persisted to disk. The `backend` picks where the values go
+ * (lmdb or fjall).
  *
- * The fjall backend is opt-in so its performance can be compared against LMDB
- * before committing to it. fjall opens its keyspace asynchronously, hence the
- * async `new`.
+ * fjall opens its keyspace asynchronously, that is why `new` here is async.
  *
  * Like `InMemWorkerConfig`, the blocks and leaf sets are shared across the
  * open/close/reopen dance that genesis init performs, so `openDatabase`
@@ -191,6 +194,7 @@ export class HybridWorkerConfig<T = undefined> implements WorkerConfig<T, Blocks
     ephemeral = false,
     compression = true,
     backend = "lmdb",
+    sharedFjallSession,
   }: {
     nodeName: string;
     chainSpec: ChainSpec;
@@ -200,12 +204,21 @@ export class HybridWorkerConfig<T = undefined> implements WorkerConfig<T, Blocks
     ephemeral?: boolean;
     compression?: boolean;
     backend?: HybridBackend;
+    /**
+     * Reuse an already-open fjall values session instead of opening a fresh
+     * keyspace. The fuzz target opens one per run and passes it on every reset,
+     * so only the in-memory blocks/leaf sets are rebuilt per vector. Ignored
+     * unless `backend === "fjall"`.
+     */
+    sharedFjallSession?: FjallValuesSession;
   }): Promise<HybridWorkerConfig<T>> {
-    // fjall opens its keyspace asynchronously; LMDB is synchronous. Either way
-    // the values store is created once here and shared across reopen.
+    // The values store is created once here and shared across reopen. When a
+    // session is given (fuzz reset reuse) we wrap it instead of opening a new one.
     const states =
       backend === "fjall"
-        ? await FjallHybridSerializedStates.new({ spec: chainSpec, blake2b, dbPath, ephemeral })
+        ? sharedFjallSession !== undefined
+          ? FjallHybridSerializedStates.fromSession(chainSpec, blake2b, sharedFjallSession)
+          : await FjallHybridSerializedStates.new({ spec: chainSpec, blake2b, dbPath, ephemeral })
         : LmdbHybridSerializedStates.new({ spec: chainSpec, blake2b, dbPath, ephemeral, compression, readOnly: false });
     return new HybridWorkerConfig(nodeName, chainSpec, workerParams, blake2b, dbPath, ephemeral, compression, states);
   }


### PR DESCRIPTION
To bring down the performance to actually match `lmdb-hybrid` for short fuzzing sessions.

Especially the picofuzz conformance tests has seen 7x slowdown due to frequent `resetState`